### PR TITLE
Add Cancel action and prompt-with-cancel helper

### DIFF
--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ToDoItemBotController.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ToDoItemBotController.java
@@ -130,6 +130,7 @@ public class ToDoItemBotController implements SpringLongPollingBot, LongPollingS
         actions.fnHide();
         actions.fnLogin();
         actions.fnRegister();
+        actions.fnCancel();
         actions.fnPendingConversation();
         actions.fnShowDonePicker();
         actions.fnMarkTaskDone();

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/ProjectTTService.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/ProjectTTService.java
@@ -1,11 +1,18 @@
 package com.springboot.MyTodoList.service;
 
 import com.springboot.MyTodoList.model.ProjectTT;
+import com.springboot.MyTodoList.model.ProjectUserTT;
+import com.springboot.MyTodoList.model.SprintTT;
+import com.springboot.MyTodoList.model.UserTT;
 import com.springboot.MyTodoList.repository.ProjectTTRepository;
+import com.springboot.MyTodoList.repository.ProjectUserTTRepository;
+import com.springboot.MyTodoList.repository.SprintTTRepository;
+import com.springboot.MyTodoList.repository.UserTTRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,6 +33,15 @@ public class ProjectTTService {
 
     @Autowired
     private ProjectTTRepository projectTTRepository;
+
+    @Autowired
+    private SprintTTRepository sprintTTRepository;
+
+    @Autowired
+    private ProjectUserTTRepository projectUserTTRepository;
+
+    @Autowired
+    private UserTTRepository userTTRepository;
 
     // ─── Read Operations ─────────────────────────────────────────────────
 
@@ -103,24 +119,44 @@ public class ProjectTTService {
     }
 
     /**
-     * Closes a project by recording today as the real end date.
+     * Closes a project and cascades the state change to all related data.
      *
-     * This is a dedicated operation so controllers don't need to
-     * fetch the full project just to set one field.
+     * Steps (all within one transaction):
+     *   1. Set date_end_real_pj = today on PROJECT_TT.
+     *   2. Mark every sprint of this project as 'done' in SPRINT_TT.
+     *   3. Remove all developer memberships from PROJECT_USER_TT
+     *      (manager memberships are preserved so they keep historical access).
      *
      * @param id  the pj_id of the project to close
      * @return the updated project, or null if not found
      */
+    @Transactional
     public ProjectTT closeProject(long id) {
         Optional<ProjectTT> existing = projectTTRepository.findById(id);
-        if (existing.isPresent()) {
-            ProjectTT project = existing.get();
-            // Record today's date as the actual project close date
-            project.setDateEndRealPj(LocalDate.now());
-            return projectTTRepository.save(project);
-        } else {
-            return null;
+        if (!existing.isPresent()) return null;
+
+        // 1. Record today as the actual close date
+        ProjectTT project = existing.get();
+        project.setDateEndRealPj(LocalDate.now());
+        projectTTRepository.save(project);
+
+        // 2. Mark all sprints of this project as done
+        List<SprintTT> sprints = sprintTTRepository.findByPjId(id);
+        for (SprintTT sprint : sprints) {
+            sprint.setStateSprint("done");
+            sprintTTRepository.save(sprint);
         }
+
+        // 3. Remove only developer members — managers keep access for history
+        List<ProjectUserTT> members = projectUserTTRepository.findByIdPjId(id);
+        for (ProjectUserTT membership : members) {
+            Optional<UserTT> userOpt = userTTRepository.findById(membership.getUserId());
+            if (userOpt.isPresent() && "developer".equals(userOpt.get().getRole())) {
+                projectUserTTRepository.deleteById(membership.getId());
+            }
+        }
+
+        return project;
     }
 
     /**

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
@@ -163,6 +163,30 @@ public class BotActions {
 
     // ─── Bot actions ─────────────────────────────────────────────────────
 
+    public void fnCancel() {
+        if (exit) return;
+        String cmd = requestText.trim();
+        if (!cmd.equals(BotCommands.CANCEL_COMMAND.getCommand()) && !cmd.equals("CANCEL")) return;
+
+        clearConversationState();
+        BotHelper.sendMessageToTelegram(chatId, "❌ Operation cancelled.", telegramClient, null);
+        if (isUserAuthenticated()) {
+            showMainMenu();
+        } else {
+            InlineKeyboardMarkup teclado = InlineKeyboardMarkup.builder()
+                .keyboardRow(new InlineKeyboardRow(
+                    InlineKeyboardButton.builder()
+                        .text("🔐 Login")
+                        .callbackData(BotCommands.LOGIN_COMMAND.getCommand())
+                        .build()
+                ))
+                .build();
+            BotHelper.sendMessageToTelegramButtons(
+                chatId, "👋 Welcome! Please log in.", telegramClient, teclado);
+        }
+        exit = true;
+    }
+
     public void fnStart() {
         if (exit) return;
 
@@ -294,6 +318,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(
             chatId, "↩️ Select a task to reopen:", telegramClient, builder.build());
         exit = true;
@@ -403,7 +430,7 @@ public class BotActions {
 
         registrationDrafts.put(chatId, new BotRegistrationDraft());
         setCurrentState(BotConversationState.WAITING_REGISTER_NAME);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_REGISTER_NAME.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_REGISTER_NAME.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -453,7 +480,7 @@ public class BotActions {
         BotRegistrationDraft draft = registrationDrafts.computeIfAbsent(chatId, k -> new BotRegistrationDraft());
         draft.setName(requestText.trim());
         setCurrentState(BotConversationState.WAITING_REGISTER_EMAIL);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_REGISTER_EMAIL.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_REGISTER_EMAIL.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -475,7 +502,7 @@ public class BotActions {
 
         draft.setEmail(requestText.trim());
         setCurrentState(BotConversationState.WAITING_REGISTER_PASSWORD);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_REGISTER_PASSWORD.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_REGISTER_PASSWORD.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -489,7 +516,7 @@ public class BotActions {
         BotRegistrationDraft draft = registrationDrafts.computeIfAbsent(chatId, k -> new BotRegistrationDraft());
         draft.setPassword(password);
         setCurrentState(BotConversationState.WAITING_REGISTER_PASSWORD_CONFIRM);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_REGISTER_PASSWORD_CONFIRM.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_REGISTER_PASSWORD_CONFIRM.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -529,7 +556,7 @@ public class BotActions {
         BotTaskDraft draft = taskDrafts.computeIfAbsent(chatId, k -> new BotTaskDraft());
         draft.setName(requestText.trim());
         setCurrentState(BotConversationState.WAITING_NEW_ITEM_DESCRIPTION);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_NEW_ITEM_DESCRIPTION.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_NEW_ITEM_DESCRIPTION.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -543,7 +570,7 @@ public class BotActions {
         BotTaskDraft draft = taskDrafts.computeIfAbsent(chatId, k -> new BotTaskDraft());
         draft.setDescription(input);
         setCurrentState(BotConversationState.WAITING_NEW_ITEM_STORY_POINTS);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_NEW_ITEM_STORY_POINTS.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_NEW_ITEM_STORY_POINTS.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -648,8 +675,11 @@ public class BotActions {
         List<SprintTT> available = getAvailableSprints();
 
         if (available.isEmpty()) {
-            BotHelper.sendMessageToTelegram(chatId, BotMessages.NO_SPRINTS_CREATED.getMessage(), telegramClient, null);
             clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId,
+                "⚠️ You have no active project or sprint assigned. Contact your manager.",
+                telegramClient, null);
+            showMainMenu();
             return;
         }
 
@@ -666,6 +696,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(chatId, BotMessages.SELECT_SPRINT.getMessage(), telegramClient, builder.build());
     }
 
@@ -693,12 +726,17 @@ public class BotActions {
             .filter(s -> !"done".equals(s.getStateSprint()))
             .collect(Collectors.toList());
 
-        // Seed only when user has no project (dev/demo fallback)
+        // Seed only when user has no project AND there are truly no sprints in the DB at all.
+        // If all sprints are 'done' (e.g. project just closed), do NOT seed — the developer
+        // simply has no active project and should see an empty list.
         if (available.isEmpty() && pjId == 0) {
-            seedSprints();
-            available = sprintTTService.findAll().stream()
-                .filter(s -> !"done".equals(s.getStateSprint()))
-                .collect(Collectors.toList());
+            boolean anySprintsInDb = !sprintTTService.findAll().isEmpty();
+            if (!anySprintsInDb) {
+                seedSprints();
+                available = sprintTTService.findAll().stream()
+                    .filter(s -> !"done".equals(s.getStateSprint()))
+                    .collect(Collectors.toList());
+            }
         }
         return available;
     }
@@ -794,6 +832,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
 
         BotHelper.sendMessageToTelegramButtons(
             chatId, BotMessages.SELECT_FEATURE.getMessage(), telegramClient, builder.build());
@@ -844,8 +885,12 @@ public class BotActions {
         task.setNameTask(draft.getName());
         task.setInfoTask(draft.getDescription());
         task.setStoryPoints(draft.getStoryPoints());
-        task.setDateStartTask(draft.getDateStart() != null ? draft.getDateStart() : sprint.getDateStartSpr());
-        task.setDateEndSetTask(draft.getDateEnd() != null ? draft.getDateEnd() : sprint.getDateEndSpr());
+        // Active sprint → creation date as start. Future sprint → sprint's own start date.
+        LocalDate startDate = "active".equals(sprint.getStateSprint())
+            ? LocalDate.now()
+            : sprint.getDateStartSpr();
+        task.setDateStartTask(startDate);
+        task.setDateEndSetTask(sprint.getDateEndSpr());
         task.setPriority(draft.getPriority());
         task.setFeatureId(draft.getFeatureId());
         task.setUserId(currentUser.getUserId());
@@ -879,7 +924,7 @@ public class BotActions {
 
         featureDrafts.put(chatId, new BotFeatureDraft());
         setCurrentState(BotConversationState.WAITING_NEW_FEATURE_NAME);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_NEW_FEATURE_NAME.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_NEW_FEATURE_NAME.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -888,7 +933,7 @@ public class BotActions {
         draft.setName(requestText.trim());
         draft.setPriority("medium");  // default — priority not asked to the user
         setCurrentState(BotConversationState.WAITING_NEW_FEATURE_DESCRIPTION);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_NEW_FEATURE_DESCRIPTION.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_NEW_FEATURE_DESCRIPTION.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -951,8 +996,11 @@ public class BotActions {
         List<SprintTT> available = getAvailableSprints();
 
         if (available.isEmpty()) {
-            BotHelper.sendMessageToTelegram(chatId, BotMessages.NO_SPRINTS_CREATED.getMessage(), telegramClient, null);
             clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId,
+                "⚠️ You have no active project or sprint assigned. Contact your manager.",
+                telegramClient, null);
+            showMainMenu();
             return;
         }
 
@@ -969,6 +1017,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(
             chatId, BotMessages.SELECT_FEATURE_SPRINT.getMessage(), telegramClient, builder.build());
     }
@@ -1151,6 +1202,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(
             chatId, "✏️ Select a task to edit:", telegramClient, builder.build());
         exit = true;
@@ -1193,15 +1247,15 @@ public class BotActions {
         switch (field) {
             case "name":
                 setCurrentState(BotConversationState.WAITING_EDIT_TASK_NEW_NAME);
-                BotHelper.sendMessageToTelegram(chatId, "📝 Enter the new task name:", telegramClient, null);
+                BotHelper.sendPromptWithCancel(chatId, "📝 Enter the new task name:", telegramClient);
                 break;
             case "description":
                 setCurrentState(BotConversationState.WAITING_EDIT_TASK_NEW_DESCRIPTION);
-                BotHelper.sendMessageToTelegram(chatId, "📄 Enter the new task description:", telegramClient, null);
+                BotHelper.sendPromptWithCancel(chatId, "📄 Enter the new task description:", telegramClient);
                 break;
             case "sp":
                 setCurrentState(BotConversationState.WAITING_EDIT_TASK_NEW_SP);
-                BotHelper.sendMessageToTelegram(chatId, "🔢 Enter the new story point value:", telegramClient, null);
+                BotHelper.sendPromptWithCancel(chatId, "🔢 Enter the new story point value:", telegramClient);
                 break;
             case "priority":
                 setCurrentState(BotConversationState.WAITING_EDIT_TASK_NEW_PRIORITY);
@@ -1229,6 +1283,9 @@ public class BotActions {
             ))
             .keyboardRow(new InlineKeyboardRow(
                 InlineKeyboardButton.builder().text("🔄 Sprint").callbackData("EDIT_FIELD:sprint").build()
+            ))
+            .keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
             ))
             .build();
         BotHelper.sendMessageToTelegramButtons(chatId, prompt, telegramClient, keyboard);
@@ -1321,6 +1378,14 @@ public class BotActions {
             return;
         }
         String priority = requestText.substring(5);
+        if ("cancel".equals(priority)) {
+            taskDrafts.remove(chatId);
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "❌ Operation cancelled.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
         if (!priority.equals("low") && !priority.equals("medium") && !priority.equals("high")) {
             showPriorityButtons();
             exit = true;
@@ -1446,6 +1511,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(chatId, "✏️ Select a feature to edit:", telegramClient, builder.build());
         exit = true;
     }
@@ -1486,6 +1554,9 @@ public class BotActions {
                 InlineKeyboardButton.builder().text("🎯 Priority").callbackData("EDIT_FEAT_FIELD:priority").build(),
                 InlineKeyboardButton.builder().text("🔄 Sprint").callbackData("EDIT_FEAT_FIELD:sprint").build()
             ))
+            .keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+            ))
             .build();
         BotHelper.sendMessageToTelegramButtons(chatId, "What would you like to edit?", telegramClient, keyboard);
     }
@@ -1500,11 +1571,11 @@ public class BotActions {
         switch (field) {
             case "name":
                 setCurrentState(BotConversationState.WAITING_EDIT_FEATURE_NEW_NAME);
-                BotHelper.sendMessageToTelegram(chatId, "📝 Enter the new feature name:", telegramClient, null);
+                BotHelper.sendPromptWithCancel(chatId, "📝 Enter the new feature name:", telegramClient);
                 break;
             case "description":
                 setCurrentState(BotConversationState.WAITING_EDIT_FEATURE_NEW_DESCRIPTION);
-                BotHelper.sendMessageToTelegram(chatId, "📄 Enter the new feature description:", telegramClient, null);
+                BotHelper.sendPromptWithCancel(chatId, "📄 Enter the new feature description:", telegramClient);
                 break;
             case "priority":
                 setCurrentState(BotConversationState.WAITING_EDIT_FEATURE_NEW_PRIORITY);
@@ -1579,6 +1650,14 @@ public class BotActions {
             return;
         }
         String priority = requestText.substring(6);
+        if ("cancel".equals(priority)) {
+            featureDrafts.remove(chatId);
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "❌ Operation cancelled.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
         if (!priority.equals("low") && !priority.equals("medium") && !priority.equals("high")) {
             showFeaturePriorityButtons();
             exit = true;
@@ -1693,7 +1772,7 @@ public class BotActions {
 
         taskDrafts.put(chatId, new BotTaskDraft());
         setCurrentState(BotConversationState.WAITING_NEW_ITEM_NAME);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.TYPE_NEW_TODO_ITEM.getMessage(), telegramClient);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.TYPE_NEW_TODO_ITEM.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -2088,7 +2167,7 @@ public class BotActions {
         } else {
             // Button click or bare "/ask" — wait for the user to type
             setCurrentState(BotConversationState.WAITING_AI_QUESTION);
-            BotHelper.sendMessageToTelegram(chatId, BotMessages.ASK_AI_PROMPT.getMessage(), telegramClient, null);
+            BotHelper.sendPromptWithCancel(chatId, BotMessages.ASK_AI_PROMPT.getMessage(), telegramClient);
         }
         exit = true;
     }
@@ -2132,7 +2211,7 @@ public class BotActions {
         }
 
         setCurrentState(BotConversationState.WAITING_AI_CREATE_DESCRIPTION);
-        BotHelper.sendMessageToTelegram(chatId, BotMessages.AI_CREATE_PROMPT.getMessage(), telegramClient, null);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.AI_CREATE_PROMPT.getMessage(), telegramClient);
         exit = true;
     }
 
@@ -2410,6 +2489,9 @@ public class BotActions {
                     .build()
             ));
         }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
         BotHelper.sendMessageToTelegramButtons(chatId, sb.toString(), telegramClient, builder.build());
         exit = true;
     }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotCommands.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotCommands.java
@@ -5,6 +5,7 @@ public enum BotCommands {
 	REGISTER_COMMAND("/register"),
 	LOGIN_COMMAND("/login"),
 	START_COMMAND("/start"),
+	CANCEL_COMMAND("/cancel"),
 	HIDE_COMMAND("/hide"),
 	TODO_LIST("/todolist"),
 	ADD_ITEM("/addtask"),

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotHelper.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotHelper.java
@@ -8,6 +8,8 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardRem
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
 
 public class BotHelper {
 
@@ -55,6 +57,19 @@ public class BotHelper {
 		} catch (Exception e) {
 			logger.error(e.getLocalizedMessage(), e);
 		}
+	}
+
+	// Para enviar mensajes de texto con botón Cancel inline
+	public static void sendPromptWithCancel(Long chatId, String text, TelegramClient bot) {
+		InlineKeyboardMarkup cancelKeyboard = InlineKeyboardMarkup.builder()
+			.keyboardRow(new InlineKeyboardRow(
+				InlineKeyboardButton.builder()
+					.text("❌ Cancel")
+					.callbackData("CANCEL")
+					.build()
+			))
+			.build();
+		sendMessageToTelegramButtons(chatId, text, bot, cancelKeyboard);
 	}
 
 	// Para enviar mensajes con botones


### PR DESCRIPTION
Introduce a universal cancel flow: add CANCEL_COMMAND and register fnCancel in the bot controller. Implement BotActions.fnCancel to clear conversation state, notify the user, and show the appropriate menu. Replace many single-message prompts with BotHelper.sendPromptWithCancel so prompts include an inline ❌ Cancel button, and add Cancel buttons to various inline keyboards (task/feature/sprint pickers, edit menus, etc.). Handle cancel input in priority selection flows to abort drafts. Add necessary helper imports and the new sendPromptWithCancel method.