### PR TITLE
Support ngrok CORS + refactor sprint state tag

### DIFF
--- a/MtdrSpring/backend/src/main/frontend/package-lock.json
+++ b/MtdrSpring/backend/src/main/frontend/package-lock.json
@@ -18516,7 +18516,8 @@
         "@babel/plugin-proposal-private-property-in-object": {
             "version": "7.21.0-placeholder-for-preset-env.2",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-            "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
+            "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+            "requires": {}
         },
         "@babel/plugin-proposal-unicode-property-regex": {
             "version": "7.18.6",
@@ -19529,12 +19530,14 @@
         "@csstools/postcss-unset-value": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-            "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
+            "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
+            "requires": {}
         },
         "@csstools/selector-specificity": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-            "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw=="
+            "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+            "requires": {}
         },
         "@emotion/babel-plugin": {
             "version": "11.11.0",
@@ -19637,7 +19640,8 @@
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw=="
+            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+            "requires": {}
         },
         "@emotion/utils": {
             "version": "1.2.1",
@@ -19723,7 +19727,8 @@
         "@heroicons/react": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-            "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ=="
+            "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+            "requires": {}
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.10",
@@ -20394,7 +20399,8 @@
         "@mui/types": {
             "version": "7.2.4",
             "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-            "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA=="
+            "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+            "requires": {}
         },
         "@mui/utils": {
             "version": "5.13.1",
@@ -21349,12 +21355,14 @@
         "acorn-import-phases": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "requires": {}
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -21423,7 +21431,8 @@
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "requires": {}
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -21742,7 +21751,8 @@
         "babel-plugin-named-asset-import": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
+            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+            "requires": {}
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.4.3",
@@ -22384,7 +22394,8 @@
         "css-declaration-sorter": {
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
-            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew=="
+            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
+            "requires": {}
         },
         "css-has-pseudo": {
             "version": "3.0.4",
@@ -22467,7 +22478,8 @@
         "css-prefers-color-scheme": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
+            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+            "requires": {}
         },
         "css-select": {
             "version": "4.3.0",
@@ -22575,7 +22587,8 @@
         "cssnano-utils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -23447,7 +23460,8 @@
         "eslint-plugin-react-hooks": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
+            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+            "requires": {}
         },
         "eslint-plugin-testing-library": {
             "version": "5.11.0",
@@ -24512,7 +24526,8 @@
         "icss-utils": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "requires": {}
         },
         "idb": {
             "version": "7.1.1",
@@ -25564,7 +25579,8 @@
         "jest-pnp-resolver": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -27309,7 +27325,8 @@
         "postcss-browser-comments": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
+            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
+            "requires": {}
         },
         "postcss-calc": {
             "version": "8.2.4",
@@ -27407,22 +27424,26 @@
         "postcss-discard-comments": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
+            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+            "requires": {}
         },
         "postcss-double-position-gradients": {
             "version": "3.1.2",
@@ -27444,7 +27465,8 @@
         "postcss-flexbugs-fixes": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
+            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
+            "requires": {}
         },
         "postcss-focus-visible": {
             "version": "6.0.4",
@@ -27465,12 +27487,14 @@
         "postcss-font-variant": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+            "requires": {}
         },
         "postcss-gap-properties": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-            "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
+            "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
+            "requires": {}
         },
         "postcss-image-set-function": {
             "version": "4.0.7",
@@ -27493,7 +27517,8 @@
         "postcss-initial": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
+            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+            "requires": {}
         },
         "postcss-js": {
             "version": "4.1.0",
@@ -27546,12 +27571,14 @@
         "postcss-logical": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
+            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+            "requires": {}
         },
         "postcss-media-minmax": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+            "requires": {}
         },
         "postcss-merge-longhand": {
             "version": "5.1.7",
@@ -27612,7 +27639,8 @@
         "postcss-modules-extract-imports": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.3",
@@ -27670,7 +27698,8 @@
         "postcss-normalize-charset": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.1.0",
@@ -27741,7 +27770,8 @@
         "postcss-opacity-percentage": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
-            "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A=="
+            "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
+            "requires": {}
         },
         "postcss-ordered-values": {
             "version": "5.1.3",
@@ -27763,7 +27793,8 @@
         "postcss-page-break": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+            "requires": {}
         },
         "postcss-place": {
             "version": "7.0.5",
@@ -27857,7 +27888,8 @@
         "postcss-replace-overflow-wrap": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+            "requires": {}
         },
         "postcss-selector-not": {
             "version": "6.0.1",
@@ -28139,7 +28171,8 @@
         "react-chartjs-2": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
-            "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="
+            "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+            "requires": {}
         },
         "react-dev-utils": {
             "version": "12.0.1",
@@ -28245,7 +28278,8 @@
         "react-moment": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/react-moment/-/react-moment-1.1.3.tgz",
-            "integrity": "sha512-8EPvlUL8u6EknPp1ISF5MQ3wx2OHJVXIP/iZc4wRh3iV3XozftZERDv9ANZeAtMlhNNQHdFoqcZHFUkBSTONfA=="
+            "integrity": "sha512-8EPvlUL8u6EknPp1ISF5MQ3wx2OHJVXIP/iZc4wRh3iV3XozftZERDv9ANZeAtMlhNNQHdFoqcZHFUkBSTONfA==",
+            "requires": {}
         },
         "react-refresh": {
             "version": "0.11.0",
@@ -29155,7 +29189,8 @@
         "style-loader": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
-            "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw=="
+            "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
+            "requires": {}
         },
         "stylehacks": {
             "version": "5.1.1",
@@ -29507,7 +29542,8 @@
                 "fdir": {
                     "version": "6.5.0",
                     "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="
+                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                    "requires": {}
                 },
                 "picomatch": {
                     "version": "4.0.4",
@@ -30061,7 +30097,8 @@
                 "ws": {
                     "version": "8.20.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-                    "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+                    "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+                    "requires": {}
                 }
             }
         },
@@ -30508,7 +30545,8 @@
         "ws": {
             "version": "7.5.10",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "requires": {}
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/MtdrSpring/backend/src/main/frontend/src/Utils/fetchAuth.ts
+++ b/MtdrSpring/backend/src/main/frontend/src/Utils/fetchAuth.ts
@@ -16,6 +16,8 @@ window.fetch = async (...args) => {
     
     // Explicitly let Spring backend know this is an API call, not browser
     headers.set('X-Requested-With', 'XMLHttpRequest');
+    // Skip ngrok browser warning interstitial when tunneling locally
+    headers.set('ngrok-skip-browser-warning', '1');
     
     config.headers = headers;
   }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/config/CorsConfig.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/config/CorsConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 /*
     This class configures CORS, and specifies which methods are allowed
@@ -23,10 +24,12 @@ public class CorsConfig {
     public CorsFilter corsFilter(){
         CorsConfiguration config = new CorsConfiguration();
         
-        // Allow localhost:3000 for development
-        config.setAllowedOrigins(List.of(
-            "http://localhost:3000",
-            "http://localhost:3001",
+        // Allow localhost for development and ngrok tunnels for local sharing
+        config.setAllowedOriginPatterns(List.of(
+            "http://localhost:*",
+            "https://*.ngrok-free.app",
+            "https://*.ngrok-free.dev",
+            "https://*.ngrok.io",
             "https://objectstorage.us-phoenix-1.oraclecloud.com",
             "https://petstore.swagger.io"
         ));

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
@@ -685,7 +685,7 @@ public class BotActions {
 
         var builder = InlineKeyboardMarkup.builder();
         for (SprintTT sprint : available) {
-            String stateTag = "inactive".equals(sprint.getStateSprint()) ? " 🕐" : " ✅";
+            String stateTag = sprintStateTag(sprint);
             String label = sprint.getNameSprint()
                 + stateTag
                 + " (" + sprint.getDateStartSpr() + " → " + sprint.getDateEndSpr() + ")";
@@ -739,6 +739,16 @@ public class BotActions {
             }
         }
         return available;
+    }
+
+    /**
+     * Returns ✅ if the sprint is currently running (active state AND start date has passed),
+     * or 🕐 if it is a future sprint not yet started.
+     */
+    private String sprintStateTag(SprintTT sprint) {
+        boolean started = sprint.getDateStartSpr() != null
+            && !sprint.getDateStartSpr().isAfter(LocalDate.now());
+        return ("active".equals(sprint.getStateSprint()) && started) ? " ✅" : " 🕐";
     }
 
     private void seedSprints() {
@@ -1006,7 +1016,7 @@ public class BotActions {
 
         var builder = InlineKeyboardMarkup.builder();
         for (SprintTT sprint : available) {
-            String stateTag = "inactive".equals(sprint.getStateSprint()) ? " 🕐" : " ✅";
+            String stateTag = sprintStateTag(sprint);
             String label = sprint.getNameSprint()
                 + stateTag
                 + " (" + sprint.getDateStartSpr() + " → " + sprint.getDateEndSpr() + ")";


### PR DESCRIPTION
Allow local/ngrok development and centralize sprint status logic. Added ngrok-skip-browser-warning header in frontend fetch to bypass ngrok interstitials and updated CorsConfig to use allowed origin patterns (wildcard localhost and ngrok domains). Refactored BotActions to extract sprintStateTag helper that considers both sprint state and start date, replacing duplicated emoji logic.