### PR TITLE
Add bulk AI task import & per-chat executors

### DIFF
--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ToDoItemBotController.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ToDoItemBotController.java
@@ -1,5 +1,10 @@
 package com.springboot.MyTodoList.controller;
 
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,7 +13,6 @@ import org.telegram.telegrambots.longpolling.BotSession;
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 import org.telegram.telegrambots.longpolling.starter.AfterBotRegistration;
 import org.telegram.telegrambots.longpolling.starter.SpringLongPollingBot;
-import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -28,9 +32,14 @@ import com.springboot.MyTodoList.service.UserTTService;
 import com.springboot.MyTodoList.util.BotActions;
 
 @Component
-public class ToDoItemBotController implements SpringLongPollingBot, LongPollingSingleThreadUpdateConsumer {
+public class ToDoItemBotController implements SpringLongPollingBot, LongPollingUpdateConsumer {
 
     private static final Logger logger = LoggerFactory.getLogger(ToDoItemBotController.class);
+
+    // One single-threaded executor per chatId:
+    //   - Messages from the same chat are processed in order (no state corruption)
+    //   - Messages from different chats run in parallel (no blocking between users)
+    private final ConcurrentHashMap<Long, ExecutorService> chatExecutors = new ConcurrentHashMap<>();
     private final ToDoItemService toDoItemService;
     private final DeepSeekService deepSeekService;
     private final GroqService groqService;
@@ -81,8 +90,39 @@ public class ToDoItemBotController implements SpringLongPollingBot, LongPollingS
     }
 
     @Override
-    public void consume(Update update) {
+    public void consume(List<Update> updates) {
+        for (Update update : updates) {
+            dispatchUpdate(update);
+        }
+    }
 
+    /**
+     * Routes each update to the per-chat executor.
+     * Same chat → sequential (preserves conversation state order).
+     * Different chats → parallel (users don't block each other).
+     */
+    private void dispatchUpdate(Update update) {
+        long chatId;
+        if (update.hasMessage() && update.getMessage().hasText()) {
+            chatId = update.getMessage().getChatId();
+        } else if (update.hasCallbackQuery()) {
+            chatId = update.getCallbackQuery().getMessage().getChatId();
+        } else {
+            return;
+        }
+
+        ExecutorService executor = chatExecutors.computeIfAbsent(
+            chatId, id -> Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "bot-chat-" + id);
+                t.setDaemon(true);
+                return t;
+            })
+        );
+
+        executor.submit(() -> processUpdate(update));
+    }
+
+    private void processUpdate(Update update) {
         String messageFromTelegram;
         long chatId;
         String username;
@@ -108,11 +148,11 @@ public class ToDoItemBotController implements SpringLongPollingBot, LongPollingS
                 logger.error(e.getLocalizedMessage(), e);
             }
         } else {
-          return;
-		    }
+            return;
+        }
 
-        String telegramIdentity = (username != null && !username.trim().isEmpty()) 
-        ? "@" + username : String.valueOf(chatId);
+        String telegramIdentity = (username != null && !username.trim().isEmpty())
+                ? "@" + username : String.valueOf(chatId);
 
         BotActions actions = new BotActions(telegramClient, toDoItemService, deepSeekService,
                 groqService,
@@ -148,9 +188,9 @@ public class ToDoItemBotController implements SpringLongPollingBot, LongPollingS
         actions.fnAddFeature();
         actions.fnAiCreate();
         actions.fnAsk();
+        actions.fnImportTasks();
         actions.fnLLM();
         actions.fnElse();
-
     }
 
     @AfterBotRegistration

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/GroqService.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/GroqService.java
@@ -36,6 +36,7 @@ public class GroqService {
     private static final Logger logger = LoggerFactory.getLogger(GroqService.class);
     private static final String MODEL = "llama-3.3-70b-versatile";
     private static final int MAX_USER_INPUT_LENGTH = 400;
+    private static final int MAX_BULK_INPUT_LENGTH = 5000;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     // Each pattern targets a well-known prompt injection technique.
@@ -99,6 +100,73 @@ public class GroqService {
         }
 
         return s.isBlank() ? null : s;
+    }
+
+    /**
+     * Sanitize bulk document text for task extraction.
+     * Keeps newlines (needed for list/section detection) but still strips injection patterns.
+     * Returns null if blank after sanitization.
+     */
+    public String sanitizeBulk(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+
+        String s = raw.trim();
+        if (s.length() > MAX_BULK_INPUT_LENGTH) {
+            s = s.substring(0, MAX_BULK_INPUT_LENGTH);
+        }
+
+        // Strip injection patterns — same security layer as sanitize()
+        for (Pattern p : INJECTION_PATTERNS) {
+            s = p.matcher(s).replaceAll("[removed]");
+        }
+
+        return s.isBlank() ? null : s;
+    }
+
+    /**
+     * Send a bulk chat completion request to Groq for document/text analysis.
+     * Uses higher token limits than ask() to handle larger documents.
+     *
+     * @param systemPrompt  Server-built extraction instructions.
+     * @param documentText  Already sanitized document content.
+     * @return Model response text (expected to be a JSON array).
+     */
+    public String askBulk(String systemPrompt, String documentText) throws IOException {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", MODEL);
+        body.put("max_tokens", 1500);
+        body.put("temperature", 0.2);
+
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", systemPrompt));
+        messages.add(Map.of("role", "user",   "content", documentText));
+        body.put("messages", messages);
+
+        HttpPost post = new HttpPost(apiUrl);
+        post.addHeader("Content-Type",  "application/json");
+        post.addHeader("Authorization", "Bearer " + apiKey);
+        post.setEntity(new StringEntity(
+            MAPPER.writeValueAsString(body), StandardCharsets.UTF_8));
+
+        String raw = httpClient.execute(post, response -> {
+            try {
+                return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            } catch (org.apache.hc.core5.http.ParseException e) {
+                throw new IOException("Failed to parse Groq response body", e);
+            }
+        });
+
+        logger.debug("Groq bulk raw response: {}", raw);
+
+        JsonNode root    = MAPPER.readTree(raw);
+        JsonNode content = root.path("choices").path(0).path("message").path("content");
+        if (!content.isMissingNode()) {
+            return content.asText();
+        }
+        JsonNode errMsg = root.path("error").path("message");
+        return errMsg.isMissingNode()
+            ? "No response received from the AI."
+            : "AI error: " + errMsg.asText();
     }
 
     /**

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotActions.java
@@ -48,6 +48,7 @@ public class BotActions {
     private static final Map<Long, BotRegistrationDraft> registrationDrafts = new ConcurrentHashMap<>();
     private static final Map<Long, BotTaskDraft> taskDrafts = new ConcurrentHashMap<>();
     private static final Map<Long, BotFeatureDraft> featureDrafts = new ConcurrentHashMap<>();
+    private static final Map<Long, BotImportDraft> importDrafts = new ConcurrentHashMap<>();
     private static final Map<Long, UserTT> authenticatedUsers = new ConcurrentHashMap<>();
 
     String requestText;
@@ -120,6 +121,7 @@ public class BotActions {
         registrationDrafts.remove(chatId);
         taskDrafts.remove(chatId);
         featureDrafts.remove(chatId);
+        importDrafts.remove(chatId);
     }
 
     private boolean isValidEmail(String email) {
@@ -266,6 +268,12 @@ public class BotActions {
                 InlineKeyboardButton.builder()
                     .text("🤖 Ask AI")
                     .callbackData(BotCommands.ASK_COMMAND.getCommand())
+                    .build()
+            ))
+            .keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder()
+                    .text("📥 Import Tasks from Text")
+                    .callbackData(BotCommands.IMPORT_TASKS.getCommand())
                     .build()
             ))
             .keyboardRow(new InlineKeyboardRow(
@@ -470,6 +478,10 @@ public class BotActions {
             case WAITING_EDIT_FEATURE_NEW_SPRINT:        handleEditFeatureNewSprint();        break;
             case WAITING_AI_QUESTION:               handleAiQuestion();              break;
             case WAITING_AI_CREATE_DESCRIPTION:     handleAiCreateDescription();     break;
+            case WAITING_IMPORT_TEXT:               handleImportText();              break;
+            case WAITING_IMPORT_SPRINT:             handleImportSprint();            break;
+            case WAITING_IMPORT_FEATURE:            handleImportFeature();           break;
+            case WAITING_IMPORT_CONFIRM:            handleImportConfirm();           break;
             default: break;
         }
     }
@@ -2335,6 +2347,340 @@ public class BotActions {
             showMainMenu();
         }
         exit = true;
+    }
+
+    // ─── Bulk import (paste text) ─────────────────────────────────────────
+
+    private static final String IMPORT_SYSTEM_PROMPT =
+        "You are a task extractor for a project management system.\n"
+        + "Extract ALL tasks, action items, or work items from the provided text.\n"
+        + "Return ONLY a valid JSON array on one line with no extra text or markdown:\n"
+        + "[{\"name\":\"...\",\"description\":\"...\",\"storyPoints\":N,\"priority\":\"HIGH\"|\"MEDIUM\"|\"LOW\"}]\n"
+        + "Rules:\n"
+        + "- name: short task title, max 80 chars\n"
+        + "- description: one-sentence summary; empty string \"\" if not clear\n"
+        + "- storyPoints: integer 1-20, estimate from complexity hints; default 3\n"
+        + "- priority: infer from urgency words; default MEDIUM\n"
+        + "- If no tasks found, return []\n"
+        + "- Do NOT wrap in code blocks or add any text outside the JSON array";
+
+    /** Entry point for the '📥 Import Tasks from Text' button. */
+    public void fnImportTasks() {
+        if (exit) return;
+        if (!isUserAuthenticated()) {
+            BotHelper.sendMessageToTelegram(chatId, "❌ You must log in first. Use /login", telegramClient, null);
+            exit = true;
+            return;
+        }
+        if (!requestText.trim().equals(BotCommands.IMPORT_TASKS.getCommand())) return;
+
+        if (groqService == null) {
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.ASK_AI_DISABLED.getMessage(), telegramClient, null);
+            exit = true;
+            return;
+        }
+
+        setCurrentState(BotConversationState.WAITING_IMPORT_TEXT);
+        BotHelper.sendPromptWithCancel(chatId, BotMessages.IMPORT_PROMPT.getMessage(), telegramClient);
+        exit = true;
+    }
+
+    /** User pasted the document text — call Groq, parse tasks, go to sprint selection. */
+    private void handleImportText() {
+        if (groqService == null) {
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.ASK_AI_DISABLED.getMessage(), telegramClient, null);
+            clearConversationState();
+            showMainMenu();
+            exit = true;
+            return;
+        }
+
+        String sanitized = groqService.sanitizeBulk(requestText);
+        if (sanitized == null) {
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.ASK_AI_EMPTY_QUESTION.getMessage(), telegramClient, null);
+            exit = true;
+            return;
+        }
+
+        BotHelper.sendMessageToTelegram(chatId, BotMessages.IMPORT_PARSING.getMessage(), telegramClient, null);
+
+        String aiResponse;
+        try {
+            aiResponse = groqService.askBulk(IMPORT_SYSTEM_PROMPT, sanitized);
+        } catch (Exception e) {
+            logger.error("Groq bulk import failed: {}", e.getMessage(), e);
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.IMPORT_PARSE_ERROR.getMessage(), telegramClient, null);
+            clearConversationState();
+            showMainMenu();
+            exit = true;
+            return;
+        }
+
+        // Extract JSON array from response — model may add surrounding text
+        String jsonStr = extractJsonArray(aiResponse);
+        if (jsonStr == null) {
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.IMPORT_NO_TASKS.getMessage(), telegramClient, null);
+            clearConversationState();
+            showMainMenu();
+            exit = true;
+            return;
+        }
+
+        try {
+            com.fasterxml.jackson.databind.JsonNode arr = JSON_MAPPER.readTree(jsonStr);
+            if (!arr.isArray() || arr.size() == 0) {
+                BotHelper.sendMessageToTelegram(chatId, BotMessages.IMPORT_NO_TASKS.getMessage(), telegramClient, null);
+                clearConversationState();
+                showMainMenu();
+                exit = true;
+                return;
+            }
+
+            List<BotImportDraft.ParsedTask> tasks = new ArrayList<>();
+            for (com.fasterxml.jackson.databind.JsonNode node : arr) {
+                BotImportDraft.ParsedTask t = new BotImportDraft.ParsedTask();
+                t.name        = node.path("name").asText("Unnamed task");
+                t.description = node.path("description").asText("");
+                t.storyPoints = Math.max(1, Math.min(20, node.path("storyPoints").asInt(3)));
+                String prio   = node.path("priority").asText("MEDIUM").toUpperCase();
+                t.priority    = (prio.equals("HIGH") || prio.equals("LOW")) ? prio : "MEDIUM";
+                tasks.add(t);
+            }
+
+            BotImportDraft draft = new BotImportDraft();
+            draft.setTasks(tasks);
+            importDrafts.put(chatId, draft);
+
+            setCurrentState(BotConversationState.WAITING_IMPORT_SPRINT);
+            BotHelper.sendMessageToTelegram(chatId,
+                "✅ Found " + tasks.size() + " task(s). Now select the sprint:",
+                telegramClient, null);
+            showSprintSelectionForImport();
+
+        } catch (Exception e) {
+            logger.error("Failed to parse import JSON: {}", e.getMessage(), e);
+            BotHelper.sendMessageToTelegram(chatId, BotMessages.IMPORT_PARSE_ERROR.getMessage(), telegramClient, null);
+            clearConversationState();
+            showMainMenu();
+        }
+        exit = true;
+    }
+
+    private void showSprintSelectionForImport() {
+        List<SprintTT> available = getAvailableSprints();
+        if (available.isEmpty()) {
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId,
+                "⚠️ You have no active project or sprint assigned. Contact your manager.",
+                telegramClient, null);
+            showMainMenu();
+            return;
+        }
+        var builder = InlineKeyboardMarkup.builder();
+        for (SprintTT sprint : available) {
+            String stateTag = sprintStateTag(sprint);
+            String label = sprint.getNameSprint() + stateTag
+                + " (" + sprint.getDateStartSpr() + " → " + sprint.getDateEndSpr() + ")";
+            builder.keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder()
+                    .text(label)
+                    .callbackData("IMPORT_SPRINT:" + sprint.getSprId())
+                    .build()
+            ));
+        }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
+        BotHelper.sendMessageToTelegramButtons(
+            chatId, BotMessages.IMPORT_SELECT_SPRINT.getMessage(), telegramClient, builder.build());
+    }
+
+    private void handleImportSprint() {
+        if (!requestText.startsWith("IMPORT_SPRINT:")) {
+            showSprintSelectionForImport();
+            exit = true;
+            return;
+        }
+        long sprintId;
+        try {
+            sprintId = Long.parseLong(requestText.substring(14));
+        } catch (NumberFormatException e) {
+            showSprintSelectionForImport();
+            exit = true;
+            return;
+        }
+
+        BotImportDraft draft = importDrafts.get(chatId);
+        if (draft == null) {
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "Session expired. Start over with Import Tasks.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
+        draft.setSprintId(sprintId);
+
+        setCurrentState(BotConversationState.WAITING_IMPORT_FEATURE);
+        showFeatureSelectionForImport(sprintId);
+        exit = true;
+    }
+
+    private void showFeatureSelectionForImport(long sprintId) {
+        List<FeatureTT> features = featureTTService.getFeaturesBySprint(sprintId);
+        if (features.isEmpty()) {
+            importDrafts.remove(chatId);
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId,
+                "⚠️ This sprint has no features. Create a feature first before importing tasks.",
+                telegramClient, null);
+            showMainMenu();
+            return;
+        }
+        var builder = InlineKeyboardMarkup.builder();
+        for (FeatureTT f : features) {
+            builder.keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder()
+                    .text("🗂 " + f.getNameFeature())
+                    .callbackData("IMPORT_FEATURE:" + f.getFeatureId())
+                    .build()
+            ));
+        }
+        builder.keyboardRow(new InlineKeyboardRow(
+            InlineKeyboardButton.builder().text("❌ Cancel").callbackData("CANCEL").build()
+        ));
+        BotHelper.sendMessageToTelegramButtons(
+            chatId, BotMessages.IMPORT_SELECT_FEATURE.getMessage(), telegramClient, builder.build());
+    }
+
+    private void handleImportFeature() {
+        if (!requestText.startsWith("IMPORT_FEATURE:")) {
+            BotImportDraft draft = importDrafts.get(chatId);
+            if (draft != null) showFeatureSelectionForImport(draft.getSprintId());
+            exit = true;
+            return;
+        }
+        long featureId;
+        try {
+            featureId = Long.parseLong(requestText.substring(15));
+        } catch (NumberFormatException e) {
+            BotImportDraft draft = importDrafts.get(chatId);
+            if (draft != null) showFeatureSelectionForImport(draft.getSprintId());
+            exit = true;
+            return;
+        }
+
+        BotImportDraft draft = importDrafts.get(chatId);
+        if (draft == null) {
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "Session expired. Start over with Import Tasks.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
+        draft.setFeatureId(featureId);
+
+        // Build preview and ask for confirmation
+        StringBuilder preview = new StringBuilder();
+        List<BotImportDraft.ParsedTask> tasks = draft.getTasks();
+        for (int i = 0; i < tasks.size(); i++) {
+            BotImportDraft.ParsedTask t = tasks.get(i);
+            preview.append(i + 1).append(". ")
+                .append(prioEmoji(t.priority.toLowerCase())).append(" *").append(t.name).append("*")
+                .append(" (").append(t.storyPoints).append(" SP)\n");
+            if (t.description != null && !t.description.isBlank()) {
+                preview.append("   _").append(t.description).append("_\n");
+            }
+        }
+
+        String confirmMsg = String.format(BotMessages.IMPORT_CONFIRM.getMessage(), tasks.size(), preview.toString());
+        InlineKeyboardMarkup keyboard = InlineKeyboardMarkup.builder()
+            .keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder()
+                    .text("✅ Create " + tasks.size() + " Task(s)")
+                    .callbackData("IMPORT_CONFIRM:YES")
+                    .build()
+            ))
+            .keyboardRow(new InlineKeyboardRow(
+                InlineKeyboardButton.builder()
+                    .text("❌ Cancel")
+                    .callbackData("CANCEL")
+                    .build()
+            ))
+            .build();
+
+        setCurrentState(BotConversationState.WAITING_IMPORT_CONFIRM);
+        BotHelper.sendMessageToTelegramButtons(chatId, confirmMsg, telegramClient, keyboard);
+        exit = true;
+    }
+
+    private void handleImportConfirm() {
+        if (!requestText.equals("IMPORT_CONFIRM:YES")) {
+            // Any other input — re-show the confirm buttons
+            exit = true;
+            return;
+        }
+
+        BotImportDraft draft = importDrafts.get(chatId);
+        if (draft == null || draft.getTasks() == null || draft.getTasks().isEmpty()) {
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "Session expired. Start over with Import Tasks.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
+
+        SprintTT sprint = sprintTTService.getSprintById(draft.getSprintId()).getBody();
+        if (sprint == null) {
+            clearConversationState();
+            BotHelper.sendMessageToTelegram(chatId, "Sprint not found. Try importing again.", telegramClient, null);
+            showMainMenu();
+            exit = true;
+            return;
+        }
+
+        UserTT currentUser = getAuthenticatedUser();
+        LocalDate startDate = "active".equals(sprint.getStateSprint())
+            ? LocalDate.now()
+            : sprint.getDateStartSpr();
+
+        int created = 0;
+        for (BotImportDraft.ParsedTask pt : draft.getTasks()) {
+            try {
+                TaskTT task = new TaskTT();
+                task.setNameTask(pt.name);
+                task.setInfoTask(pt.description != null && !pt.description.isBlank() ? pt.description : null);
+                task.setStoryPoints(pt.storyPoints);
+                task.setDateStartTask(startDate);
+                task.setDateEndSetTask(sprint.getDateEndSpr());
+                task.setPriority(pt.priority.toLowerCase());
+                task.setUserId(currentUser.getUserId());
+                task.setFeatureId(draft.getFeatureId());
+
+                TaskTT saved = taskTTService.addTask(task);
+                if (saved != null) {
+                    sprintTaskTTService.addTaskToSprint(draft.getSprintId(), saved.getTaskId());
+                    created++;
+                }
+            } catch (Exception e) {
+                logger.error("Failed to create imported task '{}': {}", pt.name, e.getMessage(), e);
+            }
+        }
+
+        clearConversationState();
+        BotHelper.sendMessageToTelegram(chatId,
+            String.format(BotMessages.IMPORT_SUCCESS.getMessage(), created),
+            telegramClient, null);
+        showMainMenu();
+        exit = true;
+    }
+
+    /** Extract first JSON array [...] from AI response text. */
+    private String extractJsonArray(String text) {
+        if (text == null) return null;
+        int start = text.indexOf('[');
+        int end   = text.lastIndexOf(']');
+        if (start == -1 || end == -1 || end <= start) return null;
+        return text.substring(start, end + 1);
     }
 
     /**

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotCommands.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotCommands.java
@@ -18,7 +18,8 @@ public enum BotCommands {
 	ASK_COMMAND("/ask"),
 	ADD_FEATURE("/addfeature"),
 	EDIT_FEATURE("/editfeature"),
-	AI_CREATE("/aicreate");
+	AI_CREATE("/aicreate"),
+	IMPORT_TASKS("/importtasks");
 
 	private final String command;
 

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotConversationState.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotConversationState.java
@@ -38,4 +38,9 @@ public enum BotConversationState {
     WAITING_AI_QUESTION,
     // AI creation flow
     WAITING_AI_CREATE_DESCRIPTION,
+    // Bulk import flow (paste text)
+    WAITING_IMPORT_TEXT,
+    WAITING_IMPORT_SPRINT,
+    WAITING_IMPORT_FEATURE,
+    WAITING_IMPORT_CONFIRM,
 }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotImportDraft.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotImportDraft.java
@@ -1,0 +1,26 @@
+package com.springboot.MyTodoList.util;
+
+import java.util.List;
+
+public class BotImportDraft {
+
+    public static class ParsedTask {
+        public String name;
+        public String description;
+        public int storyPoints;
+        public String priority;
+    }
+
+    private List<ParsedTask> tasks;
+    private long sprintId;
+    private long featureId;
+
+    public List<ParsedTask> getTasks() { return tasks; }
+    public void setTasks(List<ParsedTask> tasks) { this.tasks = tasks; }
+
+    public long getSprintId() { return sprintId; }
+    public void setSprintId(long sprintId) { this.sprintId = sprintId; }
+
+    public long getFeatureId() { return featureId; }
+    public void setFeatureId(long featureId) { this.featureId = featureId; }
+}

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotMessages.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/util/BotMessages.java
@@ -49,7 +49,16 @@ public enum BotMessages {
 	AI_CREATE_FEATURE_CONFIRM("✅ I'll create this feature:\n%s\nSelect priority below (or cancel):"),
 	AI_CREATE_UNKNOWN("❓ I could not understand what to create. Try again or use the manual buttons."),
 	AI_CREATE_CONFIRMED("✅ Created! Now select the sprint:"),
-	AI_CREATE_CANCELLED("❌ Creation cancelled.");
+	AI_CREATE_CANCELLED("❌ Creation cancelled."),
+	IMPORT_PROMPT("📋 Paste your document text below and I'll extract the tasks automatically:"),
+	IMPORT_PARSING("🤔 Extracting tasks from your text..."),
+	IMPORT_NO_TASKS("❓ No tasks found in the text. Try again with more detail or create tasks manually."),
+	IMPORT_PARSE_ERROR("❌ Failed to parse tasks. Try again or create tasks manually."),
+	IMPORT_SELECT_SPRINT("Select the sprint for all imported tasks:"),
+	IMPORT_SELECT_FEATURE("Select the feature for all imported tasks:"),
+	IMPORT_CONFIRM("📋 Found *%d task(s)*:\n\n%s\nCreate all in the selected sprint and feature?"),
+	IMPORT_SUCCESS("✅ Successfully created %d task(s)!"),
+	IMPORT_CANCELLED("❌ Import cancelled.");
 
 	private String message;
 


### PR DESCRIPTION
Introduce a bulk task-import flow powered by Groq and make bot update handling per-chat concurrent-safe. Changes include:

- Add BotImportDraft model to hold parsed tasks, sprint and feature selection.
- Extend BotActions with an import flow (fnImportTasks, handlers for text/sprint/feature/confirm), UI buttons, draft storage, JSON extraction and task creation logic.
- Add new BotCommands.IMPORT_TASKS, BotConversationState states for the import flow, and new BotMessages used during import.
- Extend GroqService with sanitizeBulk, askBulk and a MAX_BULK_INPUT_LENGTH to support larger document extraction requests and parsing of model responses.
- Change ToDoItemBotController to implement LongPollingUpdateConsumer and dispatch updates to a per-chat single-threaded ExecutorService (ConcurrentHashMap of executors) so messages from the same chat are processed sequentially while different chats run in parallel.

This enables users to paste documents to automatically extract and create tasks while improving concurrency and conversation state safety.