### PR TITLE
Add project settings, modals, and toasts

### DIFF
--- a/MtdrSpring/backend/src/main/frontend/src/App.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ProjectsPage from './Pages/ProjectsPage';
 import { Sidebar, SidebarToggle } from './Components/Sidebar';
 import PageBreadcrumb from './Components/Header/PageBreadcrumb';
 import HomeButton from './Components/Header/HomeButton';
+import Toaster from './Components/Common/Toaster';
 // Old top-bar Navigation kept importable in case we need to revert quickly,
 // but it is no longer rendered — Sidebar replaces it.
 // import Navigation from './Components/Navigation';
@@ -80,6 +81,7 @@ function App() {
         </header>
         <main className="flex-1 overflow-auto">{routes}</main>
       </div>
+      <Toaster />
     </div>
   );
 }

--- a/MtdrSpring/backend/src/main/frontend/src/Components/Common/Toaster.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/Components/Common/Toaster.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CheckCircleIcon, ExclamationCircleIcon, InformationCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { subscribeToast, ToastItem } from '../../Utils/toast';
+
+const AUTO_DISMISS_MS = 3500;
+
+const STYLES: Record<ToastItem['type'], { bar: string; icon: string; text: string; bg: string }> = {
+  success: {
+    bar:  'bg-brand',
+    icon: 'text-brand',
+    text: 'text-gray-800',
+    bg:   'bg-white',
+  },
+  error: {
+    bar:  'bg-red-500',
+    icon: 'text-red-500',
+    text: 'text-gray-800',
+    bg:   'bg-white',
+  },
+  info: {
+    bar:  'bg-blue-500',
+    icon: 'text-blue-500',
+    text: 'text-gray-800',
+    bg:   'bg-white',
+  },
+};
+
+const ICONS: Record<ToastItem['type'], React.ElementType> = {
+  success: CheckCircleIcon,
+  error:   ExclamationCircleIcon,
+  info:    InformationCircleIcon,
+};
+
+interface ActiveToast extends ToastItem {
+  exiting: boolean;
+}
+
+function ToastCard({ item, onRemove }: { item: ActiveToast; onRemove: (id: number) => void }) {
+  const s = STYLES[item.type];
+  const Icon = ICONS[item.type];
+
+  return (
+    <div
+      className={`
+        relative flex items-start gap-3 w-80 rounded-xl shadow-lg border border-gray-100
+        px-4 py-3 ${s.bg}
+        transition-all duration-300 ease-in-out
+        ${item.exiting ? 'opacity-0 translate-x-4' : 'opacity-100 translate-x-0'}
+      `}
+      role="alert"
+    >
+      {/* Left accent bar */}
+      <span className={`absolute left-0 top-2 bottom-2 w-1 rounded-full ${s.bar}`} />
+
+      <Icon className={`size-5 shrink-0 mt-0.5 ${s.icon}`} />
+
+      <p className={`flex-1 text-sm font-medium leading-snug ${s.text}`}>
+        {item.message}
+      </p>
+
+      <button
+        onClick={() => onRemove(item.id)}
+        className="shrink-0 text-gray-400 hover:text-gray-600 transition-colors"
+        aria-label="Dismiss"
+      >
+        <XMarkIcon className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+export default function Toaster() {
+  const [toasts, setToasts] = useState<ActiveToast[]>([]);
+
+  useEffect(() => {
+    return subscribeToast(item => {
+      const active: ActiveToast = { ...item, exiting: false };
+      setToasts(prev => [...prev, active]);
+
+      // Start exit animation slightly before removal
+      setTimeout(() => {
+        setToasts(prev =>
+          prev.map(t => (t.id === item.id ? { ...t, exiting: true } : t))
+        );
+      }, AUTO_DISMISS_MS - 300);
+
+      // Remove from DOM after animation completes
+      setTimeout(() => {
+        setToasts(prev => prev.filter(t => t.id !== item.id));
+      }, AUTO_DISMISS_MS);
+    });
+  }, []);
+
+  function remove(id: number) {
+    setToasts(prev => prev.map(t => (t.id === id ? { ...t, exiting: true } : t)));
+    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 300);
+  }
+
+  if (toasts.length === 0) return null;
+
+  return createPortal(
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      className="fixed bottom-5 right-5 z-[99999] flex flex-col gap-2 items-end"
+    >
+      {toasts.map(t => (
+        <ToastCard key={t.id} item={t} onRemove={remove} />
+      ))}
+    </div>,
+    document.body
+  );
+}

--- a/MtdrSpring/backend/src/main/frontend/src/Components/Sidebar/Sidebar.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/Components/Sidebar/Sidebar.tsx
@@ -26,6 +26,8 @@ interface ProjectDTO {
   dateStartPj?: string | null;
   dateEndSetPj?: string | null;
   dateEndRealPj?: string | null;
+  autoRollover?: boolean;
+  autoCloseSprints?: boolean;
 }
 
 interface SessionUser {
@@ -153,6 +155,34 @@ function Sidebar({ isOpen }: SidebarProps) {
     [addSprintFor]
   );
 
+  const handleProjectClosed = useCallback((projectId: number) => {
+    setProjects(prev => {
+      const updated = prev.map(p =>
+        p.pjId === projectId ? { ...p, dateEndRealPj: new Date().toISOString().slice(0, 10) } : p
+      );
+      saveToStorage(STORAGE_KEYS.PROJECTS, updated);
+      return updated;
+    });
+  }, []);
+
+  const handleProjectDeleted = useCallback((projectId: number) => {
+    setProjects(prev => {
+      const updated = prev.filter(p => p.pjId !== projectId);
+      saveToStorage(STORAGE_KEYS.PROJECTS, updated);
+      return updated;
+    });
+  }, []);
+
+  const handleProjectUpdated = useCallback((projectId: number, name: string, autoRollover: boolean, autoCloseSprints: boolean) => {
+    setProjects(prev => {
+      const updated = prev.map(p =>
+        p.pjId === projectId ? { ...p, namePj: name, autoRollover, autoCloseSprints } : p
+      );
+      saveToStorage(STORAGE_KEYS.PROJECTS, updated);
+      return updated;
+    });
+  }, []);
+
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [addProjectSubmitting, setAddProjectSubmitting] = useState(false);
   const [addProjectError, setAddProjectError] = useState<string | null>(null);
@@ -268,11 +298,14 @@ function Sidebar({ isOpen }: SidebarProps) {
                 key={p.pjId}
                 projectId={p.pjId}
                 projectName={p.namePj}
-                // Open the first project by default so the new structure is
-                // discoverable on first paint. Subsequent groups stay collapsed.
+                autoRollover={p.autoRollover ?? false}
+                autoCloseSprints={p.autoCloseSprints ?? false}
                 defaultOpen={idx === 0}
                 onAddSprint={openAddSprint}
                 refreshToken={sprintVersions[p.pjId] ?? 0}
+                onProjectClosed={handleProjectClosed}
+                onProjectDeleted={handleProjectDeleted}
+                onProjectUpdated={handleProjectUpdated}
               />
             ))
           )}

--- a/MtdrSpring/backend/src/main/frontend/src/Components/Sidebar/SidebarProjectGroup.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/Components/Sidebar/SidebarProjectGroup.tsx
@@ -1,19 +1,27 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   CalendarDaysIcon,
   ChartBarIcon,
   ChevronRightIcon,
+  Cog6ToothIcon,
+  EllipsisVerticalIcon,
   FolderIcon,
   PlusIcon,
+  TrashIcon,
   UserGroupIcon,
+  XCircleIcon,
 } from '@heroicons/react/24/outline';
 import SidebarItem from './SidebarItem';
 import SidebarSectionLabel from './SidebarSectionLabel';
+import CloseProjectModal from '../Common/CloseProjectModal';
+import DeleteProjectModal from '../Common/DeleteProjectModal';
 import {
   getFromStorage,
   saveToStorage,
   STORAGE_KEYS,
 } from '../../Utils/storage';
+import { toast } from '../../Utils/toast';
 
 export interface SprintLite {
   id: number;
@@ -23,142 +31,336 @@ export interface SprintLite {
 export interface SidebarProjectGroupProps {
   projectId: number;
   projectName: string;
-  /** Whether the group should start expanded (e.g. for the first project). */
+  autoRollover?: boolean;
+  autoCloseSprints?: boolean;
   defaultOpen?: boolean;
-  /** Optional callback fired when the "Add Sprint" CTA is clicked. */
   onAddSprint?: (projectId: number) => void;
-  /**
-   * External nudge to re-fetch this project's sprints — incremented by the
-   * parent after a successful sprint creation. Plain number used as a
-   * useEffect dependency, no extra plumbing needed.
-   */
   refreshToken?: number;
+  onProjectClosed?: (projectId: number) => void;
+  onProjectDeleted?: (projectId: number) => void;
+  onProjectUpdated?: (projectId: number, name: string, autoRollover: boolean, autoCloseSprints: boolean) => void;
 }
 
-/** Backend SprintTT shape — fields the sidebar uses (id, name) plus the */
-/** start date used for chronological sorting before render. */
 interface SprintDTO {
   sprId: number;
   nameSprint: string;
   dateStartSpr: string | null;
 }
 
-/**
- * Fallback shown when the backend can't be reached *and* the project is a
- * mock demo (negative ID). Real projects (positive IDs) start empty and
- * fill in once the fetch resolves.
- */
 const MOCK_SPRINTS: SprintLite[] = [
   { id: 1, name: 'Sprint 1' },
   { id: 2, name: 'Sprint 2' },
   { id: 3, name: 'Sprint 3' },
 ];
 
-/** Per-project cache key — sprints are stored separately for each project. */
 const sprintsCacheKey = (projectId: number) =>
   `${STORAGE_KEYS.SPRINTS}_${projectId}`;
 
-/**
- * Expandable project node inside the sidebar.
- *
- * Layout (when expanded):
- *   ▸ 📁 Project name           ← clickable header toggles open/closed
- *      ├─ 👥 Team               ← link to /projects/:projectId/team
- *      ├─ SPRINTS               ← section label
- *      ├─ 📅 Sprint 1           ← links to /projects/:projectId/sprints/:sprintId
- *      ├─ 📅 Sprint 2           ← (active highlight handled by NavLink)
- *      ├─ 📅 Sprint 3
- *      └─ ➕ Add Sprint         ← CTA, brand-colored
- */
+// ─── Inline Settings Modal ────────────────────────────────────────────────────
+
+function ProjectSettingsModal({
+  projectName,
+  autoRollover,
+  autoCloseSprints,
+  onClose,
+  onSave,
+}: {
+  projectName: string;
+  autoRollover: boolean;
+  autoCloseSprints: boolean;
+  onClose: () => void;
+  onSave: (name: string, autoRollover: boolean, autoCloseSprints: boolean) => Promise<void>;
+}) {
+  const [name, setName] = useState(projectName);
+  const [rollover, setRollover] = useState(autoRollover);
+  const [closeSprints, setCloseSprints] = useState(autoCloseSprints);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSave() {
+    if (!name.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSave(name.trim(), rollover, closeSprints);
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-2xl">
+        <h2 className="text-2xl font-bold text-gray-900">Project Settings</h2>
+
+        <div className="mt-6 space-y-5">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700">Project Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-base text-gray-800 outline-none focus:border-brand focus:ring-2 focus:ring-brand-lighter"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Auto Rollover</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Incomplete tasks move to next sprint automatically
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setRollover((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${
+                rollover ? 'bg-brand' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={rollover}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  rollover ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Auto Close Sprints</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Sprints close automatically when their end date passes
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setCloseSprints((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${
+                closeSprints ? 'bg-brand' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={closeSprints}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  closeSprints ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-8 flex gap-3">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-base font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={submitting || !name.trim()}
+            className="flex-1 rounded-xl bg-brand py-3 text-base font-semibold text-white shadow-md shadow-brand/25 hover:bg-brand-dark disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
 function SidebarProjectGroup({
   projectId,
   projectName,
+  autoRollover = false,
+  autoCloseSprints = false,
   defaultOpen = false,
   onAddSprint,
   refreshToken = 0,
+  onProjectClosed,
+  onProjectDeleted,
+  onProjectUpdated,
 }: SidebarProjectGroupProps) {
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
+  const [showSettings, setShowSettings] = useState(false);
+  const [liveAutoRollover, setLiveAutoRollover] = useState<boolean>(autoRollover);
+  const [liveAutoCloseSprints, setLiveAutoCloseSprints] = useState<boolean>(autoCloseSprints);
 
-  // Sprints are seeded from the per-project cache for instant paint, then
-  // refreshed from /api/sprints/project/{projectId} in the background.
-  // Mock projects (negative IDs) skip the fetch entirely and use MOCK_SPRINTS
-  // as their permanent display data.
+  // Sync whenever parent prop changes (e.g. after save updates Sidebar state)
+  useEffect(() => { setLiveAutoRollover(autoRollover); }, [autoRollover]);
+  useEffect(() => { setLiveAutoCloseSprints(autoCloseSprints); }, [autoCloseSprints]);
+  const [showCloseModal, setShowCloseModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const menuBtnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
   const [sprints, setSprints] = useState<SprintLite[]>(() => {
     if (projectId < 0) return MOCK_SPRINTS;
     return getFromStorage<SprintLite[]>(sprintsCacheKey(projectId)) ?? [];
   });
 
   useEffect(() => {
-    if (projectId < 0) return; // demo project — no backend fetch
+    if (projectId < 0) return;
     let cancelled = false;
     fetch(`/api/sprints/project/${projectId}`)
       .then(res => (res.ok ? res.json() : null))
       .then((data: SprintDTO[] | null) => {
         if (cancelled || !data) return;
-        // Sort chronologically by start date — sprints without a start date
-        // go last (treated as Infinity), so dated ones lead the list.
         const sorted = [...data].sort((a, b) => {
           const aTime = a.dateStartSpr ? new Date(a.dateStartSpr).getTime() : Infinity;
           const bTime = b.dateStartSpr ? new Date(b.dateStartSpr).getTime() : Infinity;
           return aTime - bTime;
         });
-        const mapped = sorted.map<SprintLite>(s => ({
-          id: s.sprId,
-          name: s.nameSprint,
-        }));
+        const mapped = sorted.map<SprintLite>(s => ({ id: s.sprId, name: s.nameSprint }));
         setSprints(mapped);
         saveToStorage(sprintsCacheKey(projectId), mapped);
       })
-      .catch(() => {
-        /* Keep cached/empty sprints on failure — no UI noise. */
-      });
-    return () => {
-      cancelled = true;
-    };
+      .catch(() => {});
+    return () => { cancelled = true; };
   }, [projectId, refreshToken]);
 
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        menuRef.current && !menuRef.current.contains(e.target as Node) &&
+        menuBtnRef.current && !menuBtnRef.current.contains(e.target as Node)
+      ) {
+        setMenuOpen(false);
+        setMenuPos(null);
+      }
+    }
+    if (menuOpen) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [menuOpen]);
+
   const toggle = useCallback(() => setIsOpen(o => !o), []);
-  const handleAddSprint = useCallback(() => {
-    onAddSprint?.(projectId);
-  }, [onAddSprint, projectId]);
+  const handleAddSprint = useCallback(() => { onAddSprint?.(projectId); }, [onAddSprint, projectId]);
+
+  async function handleSaveSettings(name: string, rollover: boolean, closeSprints: boolean) {
+    const res = await fetch(`/api/projects/${projectId}/settings`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ namePj: name, autoRollover: rollover, autoCloseSprints: closeSprints }),
+    });
+    if (!res.ok) {
+      toast('Failed to save changes', 'error');
+      throw new Error(`PATCH /api/projects/settings failed: ${res.status}`);
+    }
+    toast('Project settings saved');
+    setLiveAutoRollover(rollover);
+    setLiveAutoCloseSprints(closeSprints);
+    onProjectUpdated?.(projectId, name, rollover, closeSprints);
+  }
 
   return (
     <div>
-      {/* Project header — toggles expansion */}
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={isOpen}
-        className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium
-                   text-gray-700 hover:bg-brand-lighter hover:text-brand-dark
-                   transition-colors text-left"
-      >
-        <ChevronRightIcon
-          className={`size-4 shrink-0 transition-transform duration-150
-                      ${isOpen ? 'rotate-90' : ''}`}
-          aria-hidden="true"
-        />
-        <FolderIcon className="size-5 shrink-0" aria-hidden="true" />
-        <span className="truncate">{projectName}</span>
-      </button>
+      {/* Project header row */}
+      <div className="flex items-center w-full group/row">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={isOpen}
+          className="flex items-center gap-2 flex-1 min-w-0 px-3 py-2 rounded-lg text-sm font-medium
+                     text-gray-700 hover:bg-brand-lighter hover:text-brand-dark
+                     transition-colors text-left"
+        >
+          <ChevronRightIcon
+            className={`size-4 shrink-0 transition-transform duration-150 ${isOpen ? 'rotate-90' : ''}`}
+            aria-hidden="true"
+          />
+          <FolderIcon className="size-5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{projectName}</span>
+        </button>
+
+        {/* Three-dots button — portal dropdown escapes sidebar overflow-hidden */}
+        {projectId > 0 && (
+          <div className="shrink-0 mr-1">
+            <button
+              ref={menuBtnRef}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (menuOpen) {
+                  setMenuOpen(false);
+                  setMenuPos(null);
+                } else {
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  setMenuPos({ top: rect.bottom + 4, left: rect.left });
+                  setMenuOpen(true);
+                }
+              }}
+              className="flex items-center justify-center rounded-md p-1
+                         text-gray-400 hover:text-gray-700 hover:bg-gray-100
+                         opacity-0 group-hover/row:opacity-100 focus:opacity-100
+                         transition-opacity"
+              aria-label="Project options"
+            >
+              <EllipsisVerticalIcon className="size-4" />
+            </button>
+
+            {menuOpen && menuPos && createPortal(
+              <div
+                ref={menuRef}
+                style={{ position: 'fixed', top: menuPos.top, left: menuPos.left, zIndex: 9999 }}
+                className="w-52 rounded-xl border border-gray-100 bg-white py-1.5 shadow-xl shadow-gray-200/80"
+              >
+                <button
+                  onClick={async () => {
+                    setMenuOpen(false); setMenuPos(null);
+                    // Fetch fresh value from DB so modal shows current state, not cached prop
+                    try {
+                      const r = await fetch(`/api/projects/${projectId}`);
+                      if (r.ok) {
+                        const p = await r.json();
+                        setLiveAutoRollover(p.autoRollover ?? false);
+                        setLiveAutoCloseSprints(p.autoCloseSprints ?? false);
+                      }
+                    } catch {
+                      setLiveAutoRollover(autoRollover);
+                      setLiveAutoCloseSprints(autoCloseSprints);
+                    }
+                    setShowSettings(true);
+                  }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-brand-lighter"
+                >
+                  <Cog6ToothIcon className="size-4 text-gray-500" />
+                  Project Settings
+                </button>
+                <button
+                  onClick={() => { setMenuOpen(false); setMenuPos(null); setShowCloseModal(true); }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-orange-50"
+                >
+                  <XCircleIcon className="size-4 text-orange-500" />
+                  Close Project
+                </button>
+                <div className="my-1 border-t border-gray-100" />
+                <button
+                  onClick={() => { setMenuOpen(false); setMenuPos(null); setShowDeleteModal(true); }}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                >
+                  <TrashIcon className="size-4" />
+                  Delete Project
+                </button>
+              </div>,
+              document.body
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Children — Team + SPRINTS list */}
       {isOpen && (
         <div className="ml-4 mt-1 mb-1 border-l border-gray-100 pl-2 space-y-0.5">
-          <SidebarItem
-            icon={UserGroupIcon}
-            label="Team"
-            to={`/projects/${projectId}/team`}
-            dense
-          />
-
-          <SidebarItem
-            icon={ChartBarIcon}
-            label="Statistics"
-            to={`/projects/${projectId}/statistics`}
-            dense
-          />
-
+          <SidebarItem icon={UserGroupIcon} label="Team" to={`/projects/${projectId}/team`} dense />
+          <SidebarItem icon={ChartBarIcon} label="Statistics" to={`/projects/${projectId}/statistics`} dense />
           <SidebarSectionLabel>Sprints</SidebarSectionLabel>
 
           {sprints.length === 0 ? (
@@ -175,22 +377,48 @@ function SidebarProjectGroup({
             ))
           )}
 
-          {/* CTA — Add Sprint. Subtle brand-text style so the sprint list */}
-          {/* stays the visual focus; the "+" + brand color still reads as */}
-          {/* an action. Same pattern is mirrored by "Add Project" at */}
-          {/* the bottom of the project list. */}
           <button
             type="button"
             onClick={handleAddSprint}
             className="flex items-center gap-2 w-full px-3 py-1.5 rounded-md text-sm font-medium
-                       text-brand-dark hover:bg-brand-lighter
-                       transition-colors text-left"
+                       text-brand-dark hover:bg-brand-lighter transition-colors text-left"
           >
             <PlusIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
             <span className="truncate">Add Sprint</span>
           </button>
         </div>
       )}
+
+      {/* Modals */}
+      {showSettings && (
+        <ProjectSettingsModal
+          projectName={projectName}
+          autoRollover={liveAutoRollover}
+          autoCloseSprints={liveAutoCloseSprints}
+          onClose={() => setShowSettings(false)}
+          onSave={handleSaveSettings}
+        />
+      )}
+      <CloseProjectModal
+        isOpen={showCloseModal}
+        projectId={projectId}
+        projectName={projectName}
+        onClose={() => setShowCloseModal(false)}
+        onClosed={() => {
+          setShowCloseModal(false);
+          onProjectClosed?.(projectId);
+        }}
+      />
+      <DeleteProjectModal
+        isOpen={showDeleteModal}
+        projectId={projectId}
+        projectName={projectName}
+        onClose={() => setShowDeleteModal(false)}
+        onDeleted={() => {
+          setShowDeleteModal(false);
+          onProjectDeleted?.(projectId);
+        }}
+      />
     </div>
   );
 }

--- a/MtdrSpring/backend/src/main/frontend/src/Pages/ProjectsPage.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/Pages/ProjectsPage.tsx
@@ -8,9 +8,15 @@ import {
   ChartBarIcon,
   ClockIcon,
   UserGroupIcon,
+  EllipsisVerticalIcon,
+  Cog6ToothIcon,
+  TrashIcon,
 } from '@heroicons/react/24/outline';
 import TeamMemberKPIs from '../Components/TeamMemberKPIs';
+import CloseProjectModal from '../Components/Common/CloseProjectModal';
+import DeleteProjectModal from '../Components/Common/DeleteProjectModal';
 import { saveToStorage, getFromStorage, removeFromStorage, STORAGE_KEYS } from '../Utils/storage';
+import { toast } from '../Utils/toast';
 
 const mockMemberKPIs = {
   member: { name: 'Ana Ramírez', role: 'Frontend Developer' },
@@ -26,6 +32,8 @@ type ProjectDTO = {
   dateStartPj: string | null;
   dateEndSetPj: string | null;
   dateEndRealPj: string | null;
+  autoRollover: boolean;
+  autoCloseSprints: boolean;
 };
 
 type SprintDTO = {
@@ -44,7 +52,15 @@ type SprintMetrics = {
   taskCount: number;
 };
 
-type Project = { id: number; name: string };
+type Project = {
+  id: number;
+  name: string;
+  autoRollover: boolean;
+  autoCloseSprints: boolean;
+  dateStartPj: string | null;
+  dateEndSetPj: string | null;
+};
+
 type Sprint = { id: number; name: string; endDate: string; taskCount: number };
 
 function formatDate(iso: string | null): string {
@@ -54,19 +70,35 @@ function formatDate(iso: string | null): string {
 }
 
 function toProject(p: ProjectDTO): Project {
-  return { id: p.pjId, name: p.namePj };
+  return {
+    id: p.pjId,
+    name: p.namePj,
+    autoRollover: p.autoRollover ?? false,
+    autoCloseSprints: p.autoCloseSprints ?? false,
+    dateStartPj: p.dateStartPj,
+    dateEndSetPj: p.dateEndSetPj,
+  };
 }
 
-function NewProjectModal({ onClose, onCreate }: { onClose: () => void; onCreate: (name: string, endDate: string) => Promise<void> }) {
+// ─── New Project Modal ────────────────────────────────────────────────────────
+
+function NewProjectModal({
+  onClose,
+  onCreate,
+}: {
+  onClose: () => void;
+  onCreate: (name: string, endDate: string, autoRollover: boolean) => Promise<void>;
+}) {
   const [projectName, setProjectName] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [autoRollover, setAutoRollover] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   async function handleCreate() {
     if (!projectName.trim()) return;
     setSubmitting(true);
     try {
-      await onCreate(projectName.trim(), endDate);
+      await onCreate(projectName.trim(), endDate, autoRollover);
       onClose();
     } finally {
       setSubmitting(false);
@@ -80,9 +112,7 @@ function NewProjectModal({ onClose, onCreate }: { onClose: () => void; onCreate:
 
         <div className="mt-6 space-y-5">
           <div>
-            <label className="block text-sm font-semibold text-gray-700">
-              Project Name
-            </label>
+            <label className="block text-sm font-semibold text-gray-700">Project Name</label>
             <input
               type="text"
               placeholder="E.g.: Management System"
@@ -93,15 +123,37 @@ function NewProjectModal({ onClose, onCreate }: { onClose: () => void; onCreate:
           </div>
 
           <div>
-            <label className="block text-sm font-semibold text-gray-700">
-              Expected End Date
-            </label>
+            <label className="block text-sm font-semibold text-gray-700">Expected End Date</label>
             <input
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
               className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-base text-gray-800 placeholder-gray-400 outline-none focus:border-brand focus:ring-2 focus:ring-brand-lighter"
             />
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Auto Rollover</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Incomplete tasks move to next sprint automatically
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setAutoRollover((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${
+                autoRollover ? 'bg-brand' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={autoRollover}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  autoRollover ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
           </div>
         </div>
 
@@ -125,6 +177,121 @@ function NewProjectModal({ onClose, onCreate }: { onClose: () => void; onCreate:
     </div>
   );
 }
+
+// ─── Edit Project Modal (Settings) ───────────────────────────────────────────
+
+function EditProjectModal({
+  project,
+  onClose,
+  onSave,
+}: {
+  project: Project;
+  onClose: () => void;
+  onSave: (name: string, autoRollover: boolean, autoCloseSprints: boolean) => Promise<void>;
+}) {
+  const [name, setName] = useState(project.name);
+  const [autoRollover, setAutoRollover] = useState(project.autoRollover);
+  const [closeSprints, setCloseSprints] = useState(project.autoCloseSprints);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSave() {
+    if (!name.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSave(name.trim(), autoRollover, closeSprints);
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-2xl shadow-brand-dark/30">
+        <h2 className="text-2xl font-bold text-gray-900">Project Settings</h2>
+
+        <div className="mt-6 space-y-5">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700">Project Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-base text-gray-800 outline-none focus:border-brand focus:ring-2 focus:ring-brand-lighter"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Auto Rollover</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Incomplete tasks move to next sprint automatically
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setAutoRollover((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${
+                autoRollover ? 'bg-brand' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={autoRollover}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  autoRollover ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Auto Close Sprints</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                Sprints close automatically when their end date passes
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setCloseSprints((v) => !v)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2 ${
+                closeSprints ? 'bg-brand' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={closeSprints}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  closeSprints ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-8 flex gap-3">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-base font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={submitting || !name.trim()}
+            className="flex-1 rounded-xl bg-brand py-3 text-base font-semibold text-white shadow-md shadow-brand/25 hover:bg-brand-dark disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── New Sprint Modal ─────────────────────────────────────────────────────────
 
 function NewSprintModal({
   currentSprint,
@@ -158,21 +325,23 @@ function NewSprintModal({
 
         <p className="mt-3 text-base text-gray-500">
           {currentSprint
-            ? `${currentSprint.name} will end and Sprint ${nextSprintNumber} will begin.`
+            ? `Starting Sprint ${nextSprintNumber} for this project.`
             : 'No active sprint. A new sprint will be started.'}
         </p>
 
-        <div className="mt-6">
-          <label className="block text-sm font-semibold text-gray-700">
-            Sprint Duration (days)
-          </label>
-          <input
-            type="number"
-            placeholder="E.g.: 14"
-            value={duration}
-            onChange={(e) => setDuration(e.target.value)}
-            className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-base text-gray-800 placeholder-gray-400 outline-none focus:border-brand focus:ring-2 focus:ring-brand-lighter"
-          />
+        <div className="mt-6 space-y-4">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700">
+              Sprint Duration (days)
+            </label>
+            <input
+              type="number"
+              placeholder="E.g.: 14"
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+              className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-base text-gray-800 placeholder-gray-400 outline-none focus:border-brand focus:ring-2 focus:ring-brand-lighter"
+            />
+          </div>
         </div>
 
         <div className="mt-8 flex gap-3">
@@ -196,16 +365,23 @@ function NewSprintModal({
   );
 }
 
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
 export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [currentSprint, setCurrentSprint] = useState<Sprint | null>(null);
   const [metrics, setMetrics] = useState<SprintMetrics | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [showNewProject, setShowNewProject] = useState(false);
   const [showNewSprint, setShowNewSprint] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showCloseModal, setShowCloseModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const loadProjects = useCallback(async (): Promise<Project[]> => {
     const res = await fetch('/api/projects/open');
@@ -223,36 +399,32 @@ export default function ProjectsPage() {
     if (res.status === 404) return;
     if (!res.ok) throw new Error(`GET active sprint → ${res.status}`);
     const s: SprintDTO = await res.json();
-    const taskCountFallback = 0;
     setCurrentSprint({
       id: s.sprId,
       name: s.nameSprint,
       endDate: formatDate(s.dateEndSpr),
-      taskCount: taskCountFallback,
+      taskCount: 0,
     });
 
     const mRes = await fetch(`/api/sprints/${s.sprId}/metrics`);
     if (mRes.ok) {
       const m: SprintMetrics = await mRes.json();
       setMetrics(m);
-      setCurrentSprint(prev => prev ? { ...prev, taskCount: m.taskCount } : prev);
+      setCurrentSprint((prev) => (prev ? { ...prev, taskCount: m.taskCount } : prev));
     }
   }, []);
 
   useEffect(() => {
     loadProjects()
-      .then(list => {
+      .then((list) => {
         if (list.length === 0) return;
-        // Try to restore the last-viewed project id from localStorage.
-        // Validate it still exists in the fresh list; otherwise fall back to list[0].
         const savedId = getFromStorage<number>(STORAGE_KEYS.CURRENT_PROJECT);
-        const match = savedId != null ? list.find(p => p.id === savedId) : undefined;
+        const match = savedId != null ? list.find((p) => p.id === savedId) : undefined;
         setSelectedProject(match ?? list[0]);
       })
-      .catch(e => setError(e.message));
+      .catch((e) => setError(e.message));
   }, [loadProjects]);
 
-  // Persist the selected project id so refreshes / navigation don't lose context.
   useEffect(() => {
     if (selectedProject) {
       saveToStorage(STORAGE_KEYS.CURRENT_PROJECT, selectedProject.id);
@@ -261,7 +433,7 @@ export default function ProjectsPage() {
 
   useEffect(() => {
     if (!selectedProject) return;
-    loadActiveSprint(selectedProject.id).catch(e => setError(e.message));
+    loadActiveSprint(selectedProject.id).catch((e) => setError(e.message));
   }, [selectedProject, loadActiveSprint]);
 
   useEffect(() => {
@@ -269,39 +441,52 @@ export default function ProjectsPage() {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setDropdownOpen(false);
       }
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  async function handleCreateProject(name: string, endDate: string) {
+  async function handleCreateProject(name: string, endDate: string, autoRollover: boolean) {
     const body: Partial<ProjectDTO> = {
       namePj: name,
       dateStartPj: new Date().toISOString().slice(0, 10),
       dateEndSetPj: endDate || null,
+      autoRollover,
     };
     const res = await fetch('/api/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    if (!res.ok) throw new Error(`POST /api/projects → ${res.status}`);
+    if (!res.ok) {
+      toast(`Failed to create project`, 'error');
+      throw new Error(`POST /api/projects → ${res.status}`);
+    }
     const created: ProjectDTO = await res.json();
     const list = await loadProjects();
-    const match = list.find(p => p.id === created.pjId);
+    const match = list.find((p) => p.id === created.pjId);
     if (match) setSelectedProject(match);
+    toast(`Project "${name}" created`);
   }
 
-  async function handleEndProject() {
+  async function handleSaveSettings(name: string, autoRollover: boolean, autoCloseSprints: boolean) {
     if (!selectedProject) return;
-    if (!window.confirm(`Close project "${selectedProject.name}"?`)) return;
-    const res = await fetch(`/api/projects/${selectedProject.id}/close`, { method: 'PATCH' });
-    if (!res.ok) { setError(`PATCH close → ${res.status}`); return; }
+    const res = await fetch(`/api/projects/${selectedProject.id}/settings`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ namePj: name, autoRollover, autoCloseSprints }),
+    });
+    if (!res.ok) {
+      toast('Failed to save settings', 'error');
+      throw new Error(`PATCH /api/projects/settings → ${res.status}`);
+    }
     const list = await loadProjects();
-    const next = list[0] ?? null;
-    setSelectedProject(next);
-    // The closed project's id is now stale; if no projects remain, drop the cache entirely.
-    if (!next) removeFromStorage(STORAGE_KEYS.CURRENT_PROJECT);
+    const updated = list.find((p) => p.id === selectedProject.id);
+    if (updated) setSelectedProject(updated);
+    toast('Project settings saved');
   }
 
   async function handleStartSprint(durationDays: number) {
@@ -309,8 +494,9 @@ export default function ProjectsPage() {
     const start = new Date();
     const end = new Date();
     end.setDate(start.getDate() + durationDays);
+    const nextNum = currentSprint ? currentSprint.id + 1 : 1;
     const body: Partial<SprintDTO> = {
-      nameSprint: `Sprint ${currentSprint ? currentSprint.id + 1 : 1}`,
+      nameSprint: `Sprint ${nextNum}`,
       dateStartSpr: start.toISOString().slice(0, 10),
       dateEndSpr: end.toISOString().slice(0, 10),
       stateSprint: 'active',
@@ -323,7 +509,10 @@ export default function ProjectsPage() {
       body: JSON.stringify(body),
     });
     if (!res.ok) throw new Error(`POST /api/sprints → ${res.status}`);
+    const newSprint: SprintDTO = await res.json();
+
     await loadActiveSprint(selectedProject.id);
+    toast(`${newSprint.nameSprint} started`);
   }
 
   const progressPct = 0;
@@ -339,38 +528,93 @@ export default function ProjectsPage() {
         )}
 
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="relative flex-1 max-w-2xl" ref={dropdownRef}>
-            <button
-              onClick={() => setDropdownOpen(!dropdownOpen)}
-              disabled={projects.length === 0}
-              className="flex w-full items-center justify-between rounded-xl border border-gray-200 bg-white px-5 py-3.5 text-left text-lg font-semibold text-gray-800 shadow-md shadow-brand/10 hover:shadow-lg hover:shadow-brand/15 transition-shadow disabled:opacity-60"
-            >
-              {selectedProject ? selectedProject.name : 'No projects yet'}
-              <ChevronDownIcon
-                className={`size-5 text-gray-500 transition-transform duration-200 ${dropdownOpen ? 'rotate-180' : ''}`}
-              />
-            </button>
+          {/* Project selector + three-dots menu */}
+          <div className="flex flex-1 max-w-2xl items-center gap-2">
+            <div className="relative flex-1" ref={dropdownRef}>
+              <button
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+                disabled={projects.length === 0}
+                className="flex w-full items-center justify-between rounded-xl border border-gray-200 bg-white px-5 py-3.5 text-left text-lg font-semibold text-gray-800 shadow-md shadow-brand/10 hover:shadow-lg hover:shadow-brand/15 transition-shadow disabled:opacity-60"
+              >
+                {selectedProject ? selectedProject.name : 'No projects yet'}
+                <ChevronDownIcon
+                  className={`size-5 text-gray-500 transition-transform duration-200 ${dropdownOpen ? 'rotate-180' : ''}`}
+                />
+              </button>
 
-            {dropdownOpen && projects.length > 0 && (
-              <div className="absolute z-20 mt-2 w-full rounded-xl border border-gray-100 bg-white py-2 shadow-xl shadow-brand-dark/15">
-                {projects.map((project) => (
+              {dropdownOpen && projects.length > 0 && (
+                <div className="absolute z-20 mt-2 w-full rounded-xl border border-gray-100 bg-white py-2 shadow-xl shadow-brand-dark/15">
+                  {projects.map((project) => (
+                    <button
+                      key={project.id}
+                      onClick={() => {
+                        setSelectedProject(project);
+                        setDropdownOpen(false);
+                      }}
+                      className={`block w-full px-5 py-3 text-left text-base hover:bg-brand-lighter ${
+                        selectedProject?.id === project.id
+                          ? 'bg-brand-lighter font-semibold text-brand-dark'
+                          : 'text-gray-700'
+                      }`}
+                    >
+                      {project.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Three-dots menu */}
+            <div className="relative" ref={menuRef}>
+              <button
+                onClick={() => setMenuOpen((v) => !v)}
+                disabled={!selectedProject}
+                className="flex items-center justify-center rounded-xl border border-gray-200 bg-white p-3 shadow-md shadow-brand/10 hover:shadow-lg hover:shadow-brand/15 transition-shadow disabled:opacity-40"
+                aria-label="Project options"
+              >
+                <EllipsisVerticalIcon className="size-5 text-gray-600" />
+              </button>
+
+              {menuOpen && selectedProject && (
+                <div className="absolute right-0 z-30 mt-2 w-52 rounded-xl border border-gray-100 bg-white py-2 shadow-xl shadow-brand-dark/15">
                   <button
-                    key={project.id}
-                    onClick={() => {
-                      setSelectedProject(project);
-                      setDropdownOpen(false);
+                    onClick={async () => {
+                      setMenuOpen(false);
+                      // Re-fetch fresh project data so settings modal shows DB value
+                      if (selectedProject) {
+                        try {
+                          const r = await fetch(`/api/projects/${selectedProject.id}`);
+                          if (r.ok) {
+                            const p = await r.json();
+                            setSelectedProject(prev => prev ? { ...prev, autoRollover: p.autoRollover ?? false, autoCloseSprints: p.autoCloseSprints ?? false } : prev);
+                          }
+                        } catch { /* use cached value */ }
+                      }
+                      setShowSettings(true);
                     }}
-                    className={`block w-full px-5 py-3 text-left text-base hover:bg-brand-lighter ${
-                      selectedProject?.id === project.id
-                        ? 'bg-brand-lighter font-semibold text-brand-dark'
-                        : 'text-gray-700'
-                    }`}
+                    className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-brand-lighter"
                   >
-                    {project.name}
+                    <Cog6ToothIcon className="size-4 text-gray-500" />
+                    Project Settings
                   </button>
-                ))}
-              </div>
-            )}
+                  <button
+                    onClick={() => { setMenuOpen(false); setShowCloseModal(true); }}
+                    className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-brand-lighter"
+                  >
+                    <XCircleIcon className="size-4 text-orange-500" />
+                    Close Project
+                  </button>
+                  <div className="my-1 border-t border-gray-100" />
+                  <button
+                    onClick={() => { setMenuOpen(false); setShowDeleteModal(true); }}
+                    className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-red-600 hover:bg-red-50"
+                  >
+                    <TrashIcon className="size-4" />
+                    Delete Project
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
 
           <div className="flex gap-3">
@@ -380,14 +624,6 @@ export default function ProjectsPage() {
             >
               <PlusIcon className="size-5" />
               New Project
-            </button>
-            <button
-              onClick={handleEndProject}
-              disabled={!selectedProject}
-              className="flex items-center gap-2 rounded-xl bg-orange-500 px-5 py-3 text-base font-semibold text-white shadow-md shadow-orange-500/25 hover:bg-orange-600 disabled:opacity-50"
-            >
-              <XCircleIcon className="size-5" />
-              End Project
             </button>
           </div>
         </div>
@@ -482,6 +718,43 @@ export default function ProjectsPage() {
           currentSprint={currentSprint}
           onClose={() => setShowNewSprint(false)}
           onStart={handleStartSprint}
+        />
+      )}
+      {showSettings && selectedProject && (
+        <EditProjectModal
+          project={selectedProject}
+          onClose={() => setShowSettings(false)}
+          onSave={handleSaveSettings}
+        />
+      )}
+      {showCloseModal && selectedProject && (
+        <CloseProjectModal
+          isOpen={showCloseModal}
+          projectId={selectedProject.id}
+          projectName={selectedProject.name}
+          onClose={() => setShowCloseModal(false)}
+          onClosed={async () => {
+            setShowCloseModal(false);
+            const list = await loadProjects();
+            const next = list[0] ?? null;
+            setSelectedProject(next);
+            if (!next) removeFromStorage(STORAGE_KEYS.CURRENT_PROJECT);
+          }}
+        />
+      )}
+      {showDeleteModal && selectedProject && (
+        <DeleteProjectModal
+          isOpen={showDeleteModal}
+          projectId={selectedProject.id}
+          projectName={selectedProject.name}
+          onClose={() => setShowDeleteModal(false)}
+          onDeleted={async () => {
+            setShowDeleteModal(false);
+            const list = await loadProjects();
+            const next = list[0] ?? null;
+            setSelectedProject(next);
+            if (!next) removeFromStorage(STORAGE_KEYS.CURRENT_PROJECT);
+          }}
         />
       )}
     </div>

--- a/MtdrSpring/backend/src/main/frontend/src/Pages/SprintPage.tsx
+++ b/MtdrSpring/backend/src/main/frontend/src/Pages/SprintPage.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   ArrowTrendingUpIcon,
   CalendarIcon,
   CheckCircleIcon,
   ClockIcon,
   ExclamationCircleIcon,
+  StopIcon,
 } from '@heroicons/react/24/outline';
 import { KpiCard } from '../Components/Team'; // shared visual primitive — promote to /Common if it spreads further
 import {
@@ -29,6 +30,7 @@ import TaskDetailModal from '../Components/Common/TaskDetailModal';
 import type { TaskDetailData } from '../Components/Common/TaskDetailModal';
 import PageLoading from '../Components/Common/PageLoading';
 import { getFromStorage, saveToStorage, STORAGE_KEYS } from '../Utils/storage';
+import { toast } from '../Utils/toast';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock data — visual-only until the sprint endpoints are wired.
@@ -38,6 +40,7 @@ import { getFromStorage, saveToStorage, STORAGE_KEYS } from '../Utils/storage';
 interface ProjectDTO {
   pjId: number;
   namePj: string;
+  autoCloseSprints?: boolean;
 }
 
 /** Backend SprintTT shape — only the fields this page consumes. */
@@ -342,6 +345,7 @@ export default function SprintPage() {
   }>();
   const projectId = rawProjectId ? Number(rawProjectId) : undefined;
   const sprintId = rawSprintId ? Number(rawSprintId) : undefined;
+  const navigate = useNavigate();
 
   // Resolve project name from the cached project list (filled by the sidebar).
   // When backend wiring lands this becomes a fetch keyed by projectId.
@@ -374,6 +378,12 @@ export default function SprintPage() {
   );
   const [usersLoading, setUsersLoading] = useState(true);
   const [contentView, setContentView] = useState<SprintContentView>('features');
+
+  // autoCloseSprints setting for the current project — if false, show manual
+  // "Terminar Sprint" button on active sprints.
+  const [autoCloseSprints, setAutoCloseSprints] = useState<boolean>(true); // optimistic default hides button until fetched
+  const [showEndConfirm, setShowEndConfirm] = useState(false);
+  const [endingsprint, setEndingSprint] = useState(false);
 
   useEffect(() => {
     if (sprintId == null || sprintId < 0) {
@@ -436,6 +446,49 @@ export default function SprintPage() {
       cancelled = true;
     };
   }, [sprintId]);
+
+  // Fetch project autoCloseSprints so we know whether to show the manual
+  // "Terminar Sprint" button. Runs whenever the sprint's pjId is known.
+  useEffect(() => {
+    const pid = sprintDto?.pjId ?? projectId;
+    if (pid == null || pid < 0) return;
+    let cancelled = false;
+    fetch(`/api/projects/${pid}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: ProjectDTO | null) => {
+        if (cancelled || !data) return;
+        setAutoCloseSprints(data.autoCloseSprints ?? false);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [sprintDto?.pjId, projectId]);
+
+  // Handler for the "Terminar Sprint" button
+  const handleEndSprint = useCallback(async () => {
+    if (!sprintId) return;
+    setEndingSprint(true);
+    try {
+      const res = await fetch(`/api/sprints/${sprintId}/end`, { method: 'PATCH' });
+      if (!res.ok && res.status !== 204) {
+        toast('Failed to end sprint', 'error');
+        return;
+      }
+      // If a next sprint was activated, navigate there; otherwise go to project
+      if (res.status === 200) {
+        const next = await res.json() as { sprId: number };
+        toast('Sprint closed — next sprint activated');
+        navigate(`/projects/${projectId}/sprints/${next.sprId}`);
+      } else {
+        toast('Sprint closed — no next sprint found');
+        navigate(`/projects/${projectId}`);
+      }
+    } catch {
+      toast('Failed to end sprint', 'error');
+    } finally {
+      setEndingSprint(false);
+      setShowEndConfirm(false);
+    }
+  }, [sprintId, projectId, navigate]);
 
   // One-time fetch of all users for the developer-name lookup. Lives across
   // sprint navigations (deps: []) — same map serves every feature row.
@@ -781,21 +834,68 @@ export default function SprintPage() {
       ) : (
       <div className="max-w-7xl mx-auto space-y-8">
         {/* Header */}
-        <header>
-          <h1 className="text-3xl font-bold text-gray-900">
-            {projectName} - {sprint.name}
-          </h1>
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-gray-500 mt-2">
-            <span className="inline-flex items-center gap-1.5">
-              <CalendarIcon className="h-4 w-4" aria-hidden="true" />
-              {sprint.startDate} - {sprint.endDate}
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
-              {sprint.totalTasks} total tasks
-            </span>
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">
+              {projectName} - {sprint.name}
+            </h1>
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-gray-500 mt-2">
+              <span className="inline-flex items-center gap-1.5">
+                <CalendarIcon className="h-4 w-4" aria-hidden="true" />
+                {sprint.startDate} - {sprint.endDate}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
+                {sprint.totalTasks} total tasks
+              </span>
+            </div>
           </div>
+
+          {/* "Terminar Sprint" — visible only when sprint is active, has started, and autoCloseSprints=false */}
+          {sprintDto?.stateSprint === 'active'
+            && !autoCloseSprints
+            && sprintDto.dateStartSpr != null
+            && new Date(sprintDto.dateStartSpr) <= new Date()
+            && (
+            <button
+              type="button"
+              onClick={() => setShowEndConfirm(true)}
+              className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-semibold text-red-700 hover:bg-red-100 transition-colors"
+            >
+              <StopIcon className="h-4 w-4" />
+              Terminar Sprint
+            </button>
+          )}
         </header>
+
+        {/* Terminar Sprint — confirm dialog */}
+        {showEndConfirm && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+            <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-2xl">
+              <h2 className="text-xl font-bold text-gray-900">Terminar Sprint</h2>
+              <p className="mt-3 text-sm text-gray-500">
+                ¿Seguro que quieres cerrar <span className="font-semibold text-gray-700">{sprint.name}</span>?
+                El siguiente sprint más próximo se activará automáticamente.
+              </p>
+              <div className="mt-6 flex gap-3">
+                <button
+                  onClick={() => setShowEndConfirm(false)}
+                  disabled={endingsprint}
+                  className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={handleEndSprint}
+                  disabled={endingsprint}
+                  className="flex-1 rounded-xl bg-red-600 py-3 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+                >
+                  {endingsprint ? 'Cerrando…' : 'Sí, terminar'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Sprint KPIs */}
         <section

--- a/MtdrSpring/backend/src/main/frontend/src/Utils/toast.ts
+++ b/MtdrSpring/backend/src/main/frontend/src/Utils/toast.ts
@@ -1,0 +1,33 @@
+// ─── Lightweight imperative toast system ─────────────────────────────────────
+//
+// Usage (anywhere in the app):
+//   import { toast } from '../Utils/toast';
+//   toast('Changes saved!');
+//   toast('Something went wrong', 'error');
+//
+// The <Toaster /> component in App.tsx subscribes and renders the notifications.
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+type Listener = (item: ToastItem) => void;
+
+let _listeners: Listener[] = [];
+let _idCounter = 0;
+
+export function toast(message: string, type: ToastType = 'success'): void {
+  const item: ToastItem = { id: ++_idCounter, message, type };
+  _listeners.forEach(fn => fn(item));
+}
+
+export function subscribeToast(fn: Listener): () => void {
+  _listeners.push(fn);
+  return () => {
+    _listeners = _listeners.filter(l => l !== fn);
+  };
+}

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/MyTodoListApplication.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/MyTodoListApplication.java
@@ -4,8 +4,10 @@ import com.springboot.MyTodoList.config.BotProps;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableConfigurationProperties(BotProps.class)
 public class MyTodoListApplication {
 

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ProjectTTController.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/ProjectTTController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -56,6 +57,22 @@ public class ProjectTTController {
             return new ResponseEntity<>(updated, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @PatchMapping(value = "/projects/{id}/settings")
+    public ResponseEntity<ProjectTT> updateProjectSettings(
+            @PathVariable long id,
+            @RequestBody Map<String, Object> body) {
+        try {
+            String namePj = (String) body.getOrDefault("namePj", null);
+            boolean autoRollover = Boolean.TRUE.equals(body.get("autoRollover"));
+            boolean autoCloseSprints = Boolean.TRUE.equals(body.get("autoCloseSprints"));
+            ProjectTT updated = projectTTService.updateProjectSettings(id, namePj, autoRollover, autoCloseSprints);
+            if (updated == null) return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(updated, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/SprintTTController.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/controller/SprintTTController.java
@@ -83,6 +83,40 @@ public class SprintTTController {
         }
     }
 
+    /**
+     * Manual sprint termination endpoint — called when the manager presses
+     * "Terminar Sprint" on the sprint page (i.e. project has autoCloseSprints=false).
+     *
+     * Closes the sprint and activates the closest available next sprint.
+     * Returns the newly activated sprint (or 204 NO_CONTENT if none existed).
+     */
+    @PatchMapping(value = "/sprints/{id}/end")
+    public ResponseEntity<SprintTT> endSprint(@PathVariable long id) {
+        try {
+            SprintTT next = sprintTTService.closeSprintAndActivateNext(id);
+            if (next == null) {
+                // Sprint was closed but no next sprint found — still success
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            }
+            return new ResponseEntity<>(next, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PatchMapping(value = "/sprints/{id}/close")
+    public ResponseEntity<SprintTT> closeSprint(
+            @PathVariable long id,
+            @RequestParam(required = false) Long nextSprintId) {
+        try {
+            SprintTT closed = sprintTTService.closeSprint(id, nextSprintId);
+            if (closed == null) return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(closed, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     @DeleteMapping(value = "/sprints/{id}")
     public ResponseEntity<Boolean> deleteSprint(@PathVariable long id) {
         Boolean flag = false;

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/model/ProjectTT.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/model/ProjectTT.java
@@ -67,6 +67,23 @@ public class ProjectTT {
     @Column(name = "DATE_END_REAL_PJ")
     private LocalDate dateEndRealPj;
 
+    /*
+     * When true, incomplete tasks (stateTask 'active' or 'delayed') are
+     * automatically copied to the next sprint when the current sprint is closed.
+     * Defaults to false — opt-in per project.
+     */
+    @Column(name = "AUTO_ROLLOVER", columnDefinition = "NUMBER(1) DEFAULT 0")
+    private boolean autoRollover = false;
+
+    /*
+     * When true, a daily scheduled job (@Scheduled) automatically marks sprints
+     * as 'done' when their dateEndSpr is in the past.
+     * When false, the manager must press "Terminar Sprint" manually on the sprint page.
+     * Defaults to false — opt-in per project.
+     */
+    @Column(name = "AUTO_CLOSE_SPRINTS", columnDefinition = "NUMBER(1) DEFAULT 0")
+    private boolean autoCloseSprints = false;
+
     // ─── Constructors ────────────────────────────────────────────────────
 
     /** Required no-args constructor for JPA proxy instantiation. */
@@ -80,6 +97,7 @@ public class ProjectTT {
         this.dateStartPj    = dateStartPj;
         this.dateEndSetPj   = dateEndSetPj;
         this.dateEndRealPj  = dateEndRealPj;
+        this.autoRollover   = false;
     }
 
     // ─── Getters & Setters ───────────────────────────────────────────────
@@ -98,4 +116,10 @@ public class ProjectTT {
 
     public LocalDate getDateEndRealPj()            { return dateEndRealPj; }
     public void setDateEndRealPj(LocalDate d)      { this.dateEndRealPj = d; }
+
+    public boolean isAutoRollover()                { return autoRollover; }
+    public void setAutoRollover(boolean b)         { this.autoRollover = b; }
+
+    public boolean isAutoCloseSprints()            { return autoCloseSprints; }
+    public void setAutoCloseSprints(boolean b)     { this.autoCloseSprints = b; }
 }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/repository/SprintTTRepository.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/repository/SprintTTRepository.java
@@ -3,9 +3,12 @@ package com.springboot.MyTodoList.repository;
 import com.springboot.MyTodoList.model.SprintTT;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,4 +70,24 @@ public interface SprintTTRepository extends JpaRepository<SprintTT, Long> {
      *   called with stateSprint = "active"
      */
     Optional<SprintTT> findByPjIdAndStateSprint(long pjId, String stateSprint);
+
+    /*
+     * All non-done sprints for a project except the one being closed.
+     * Used by closeSprintAndActivateNext() to find the nearest next sprint.
+     *
+     * Generated SQL:
+     *   SELECT * FROM sprint_tt
+     *   WHERE pj_id = ? AND spr_id <> ? AND state_sprint <> 'done'
+     */
+    List<SprintTT> findByPjIdAndSprIdNotAndStateSprintNot(long pjId, long excludeId, String excludeState);
+
+    /*
+     * Active sprints whose end date is strictly before today.
+     * Used by the daily scheduler to auto-close expired sprints
+     * for projects with autoCloseSprints = true.
+     *
+     * JPQL — joins to PROJECT_TT via pjId field on SprintTT.
+     */
+    @Query("SELECT s FROM SprintTT s WHERE s.stateSprint = 'active' AND s.dateEndSpr < :today")
+    List<SprintTT> findExpiredActiveSprints(@Param("today") LocalDate today);
 }

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/ProjectTTService.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/ProjectTTService.java
@@ -112,10 +112,32 @@ public class ProjectTTService {
             project.setDateStartPj(updatedProject.getDateStartPj());
             project.setDateEndSetPj(updatedProject.getDateEndSetPj());
             project.setDateEndRealPj(updatedProject.getDateEndRealPj());
+            project.setAutoRollover(updatedProject.isAutoRollover());
+            project.setAutoCloseSprints(updatedProject.isAutoCloseSprints());
             return projectTTRepository.save(project);
         } else {
             return null;
         }
+    }
+
+    /**
+     * Partial update — only touches namePj and autoRollover.
+     * All other fields (dates, etc.) are read from the existing DB row,
+     * so they can never be accidentally wiped by a partial payload.
+     *
+     * @param id           the pj_id to update
+     * @param namePj       new project name
+     * @param autoRollover new rollover setting
+     * @return the saved project, or null if not found
+     */
+    public ProjectTT updateProjectSettings(long id, String namePj, boolean autoRollover, boolean autoCloseSprints) {
+        Optional<ProjectTT> existing = projectTTRepository.findById(id);
+        if (!existing.isPresent()) return null;
+        ProjectTT project = existing.get();
+        if (namePj != null && !namePj.isBlank()) project.setNamePj(namePj);
+        project.setAutoRollover(autoRollover);
+        project.setAutoCloseSprints(autoCloseSprints);
+        return projectTTRepository.save(project);
     }
 
     /**

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/SprintScheduler.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/SprintScheduler.java
@@ -1,0 +1,100 @@
+package com.springboot.MyTodoList.service;
+
+import com.springboot.MyTodoList.model.ProjectTT;
+import com.springboot.MyTodoList.model.SprintTT;
+import com.springboot.MyTodoList.repository.ProjectTTRepository;
+import com.springboot.MyTodoList.repository.SprintTTRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * ============================================================
+ *  SprintScheduler
+ * ============================================================
+ *
+ *  Runs daily at midnight to auto-close expired sprints for
+ *  projects that have autoCloseSprints = true.
+ *
+ *  "Expired" means: stateSprint = 'active' AND dateEndSpr < today.
+ *
+ *  For each expired sprint it delegates to
+ *  SprintTTService.closeSprintAndActivateNext(), which:
+ *    - marks the sprint as 'done'
+ *    - activates the nearest next sprint (by dateStartSpr proximity)
+ *    - rolls over incomplete tasks if the project also has autoRollover=true
+ *
+ *  The cron expression "0 0 0 * * *" fires at 00:00:00 server time every day.
+ *  In production, server time should be set to the team's timezone (e.g. UTC-6
+ *  for Mexico City) or use a ZonedSchedulingConfigurer bean.
+ */
+@Component
+public class SprintScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(SprintScheduler.class);
+
+    @Autowired
+    private SprintTTRepository sprintTTRepository;
+
+    @Autowired
+    private ProjectTTRepository projectTTRepository;
+
+    @Autowired
+    private SprintTTService sprintTTService;
+
+    /**
+     * Daily job — fires at midnight every day.
+     *
+     * For every active sprint whose end date is in the past, check if
+     * its parent project has autoCloseSprints enabled. If yes, close it
+     * and activate the nearest next sprint.
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void autoCloseExpiredSprints() {
+        LocalDate today = LocalDate.now();
+        List<SprintTT> expired = sprintTTRepository.findExpiredActiveSprints(today);
+
+        if (expired.isEmpty()) {
+            log.debug("SprintScheduler: no expired active sprints found for {}", today);
+            return;
+        }
+
+        log.info("SprintScheduler: found {} expired sprint(s) to evaluate on {}", expired.size(), today);
+
+        for (SprintTT sprint : expired) {
+            Optional<ProjectTT> projectOpt = projectTTRepository.findById(sprint.getPjId());
+            if (projectOpt.isEmpty()) {
+                log.warn("SprintScheduler: sprint {} references missing project {}", sprint.getSprId(), sprint.getPjId());
+                continue;
+            }
+
+            ProjectTT project = projectOpt.get();
+            if (!project.isAutoCloseSprints()) {
+                log.debug("SprintScheduler: skipping sprint {} — project {} has autoCloseSprints=false",
+                        sprint.getSprId(), project.getNamePj());
+                continue;
+            }
+
+            try {
+                SprintTT next = sprintTTService.closeSprintAndActivateNext(sprint.getSprId());
+                if (next != null) {
+                    log.info("SprintScheduler: closed sprint '{}' (id={}) → activated '{}' (id={}) for project '{}'",
+                            sprint.getNameSprint(), sprint.getSprId(),
+                            next.getNameSprint(), next.getSprId(),
+                            project.getNamePj());
+                } else {
+                    log.info("SprintScheduler: closed sprint '{}' (id={}) for project '{}' — no next sprint found",
+                            sprint.getNameSprint(), sprint.getSprId(), project.getNamePj());
+                }
+            } catch (Exception e) {
+                log.error("SprintScheduler: failed to close sprint {} — {}", sprint.getSprId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/SprintTTService.java
+++ b/MtdrSpring/backend/src/main/java/com/springboot/MyTodoList/service/SprintTTService.java
@@ -1,7 +1,10 @@
 package com.springboot.MyTodoList.service;
 
+import com.springboot.MyTodoList.model.ProjectTT;
 import com.springboot.MyTodoList.model.SprintMetricsResult;
 import com.springboot.MyTodoList.model.SprintTT;
+import com.springboot.MyTodoList.model.SprintTaskTT;
+import com.springboot.MyTodoList.repository.ProjectTTRepository;
 import com.springboot.MyTodoList.repository.SprintTaskTTRepository;
 import com.springboot.MyTodoList.repository.SprintTTRepository;
 import com.springboot.MyTodoList.repository.TaskTTRepository;
@@ -9,7 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,6 +53,9 @@ public class SprintTTService {
     /** Repository for SPRINT_TT — primary data source for this service. */
     @Autowired
     private SprintTTRepository sprintTTRepository;
+
+    @Autowired
+    private ProjectTTRepository projectTTRepository;
 
     /**
      * Repository for TASK_TT — used in getSprintMetrics() to sum story_points
@@ -177,6 +186,104 @@ public class SprintTTService {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    /**
+     * Closes a sprint (marks it 'done') and, if the project has autoRollover
+     * enabled, copies all incomplete tasks to the target next sprint.
+     *
+     * Rollover: any task with stateTask 'active' or 'delayed' in this sprint
+     * is inserted into nextSprintId with stateTask = 'active'.
+     *
+     * @param sprId         the sprint to close
+     * @param nextSprintId  the sprint to receive rolled-over tasks (nullable — no rollover if null)
+     * @return the updated sprint, or null if not found
+     */
+    @Transactional
+    public SprintTT closeSprint(long sprId, Long nextSprintId) {
+        Optional<SprintTT> existing = sprintTTRepository.findById(sprId);
+        if (!existing.isPresent()) return null;
+
+        SprintTT sprint = existing.get();
+        sprint.setStateSprint("done");
+        sprintTTRepository.save(sprint);
+
+        if (nextSprintId != null) {
+            Optional<ProjectTT> projectOpt = projectTTRepository.findById(sprint.getPjId());
+            if (projectOpt.isPresent() && projectOpt.get().isAutoRollover()) {
+                List<SprintTaskTT> active  = sprintTaskTTRepository.findByIdSprIdAndStateTask(sprId, "active");
+                List<SprintTaskTT> delayed = sprintTaskTTRepository.findByIdSprIdAndStateTask(sprId, "delayed");
+
+                for (SprintTaskTT st : active) {
+                    sprintTaskTTRepository.save(new SprintTaskTT(nextSprintId, st.getId().getTaskId(), "active"));
+                }
+                for (SprintTaskTT st : delayed) {
+                    sprintTaskTTRepository.save(new SprintTaskTT(nextSprintId, st.getId().getTaskId(), "active"));
+                }
+            }
+        }
+
+        return sprint;
+    }
+
+    /**
+     * Closes a sprint and activates the closest candidate sprint.
+     *
+     * Algorithm:
+     *   1. Mark this sprint as 'done'.
+     *   2. Find all non-done sprints for the same project (excluding itself).
+     *   3. Pick the one whose dateStartSpr is closest to this sprint's dateEndSpr
+     *      using MIN(|dateStart_candidate - dateEnd_closed|). Sprints with no
+     *      start date are given lowest priority (treated as Infinity distance).
+     *   4. Mark that sprint as 'active'.
+     *   5. If project has autoRollover, copy incomplete tasks to the new sprint.
+     *
+     * @param sprId  the sprint to close
+     * @return the newly activated sprint, or null if sprId not found
+     */
+    @Transactional
+    public SprintTT closeSprintAndActivateNext(long sprId) {
+        Optional<SprintTT> existing = sprintTTRepository.findById(sprId);
+        if (!existing.isPresent()) return null;
+
+        SprintTT sprint = existing.get();
+        sprint.setStateSprint("done");
+        sprintTTRepository.save(sprint);
+
+        // Find nearest candidate sprint
+        List<SprintTT> candidates = sprintTTRepository
+                .findByPjIdAndSprIdNotAndStateSprintNot(sprint.getPjId(), sprId, "done");
+
+        SprintTT nextSprint = candidates.stream()
+                .min(Comparator.comparingLong(c -> {
+                    if (c.getDateStartSpr() == null || sprint.getDateEndSpr() == null) {
+                        return Long.MAX_VALUE;
+                    }
+                    return Math.abs(
+                        c.getDateStartSpr().toEpochDay() - sprint.getDateEndSpr().toEpochDay()
+                    );
+                }))
+                .orElse(null);
+
+        if (nextSprint != null) {
+            nextSprint.setStateSprint("active");
+            sprintTTRepository.save(nextSprint);
+
+            // Rollover incomplete tasks if project has it enabled
+            Optional<ProjectTT> projectOpt = projectTTRepository.findById(sprint.getPjId());
+            if (projectOpt.isPresent() && projectOpt.get().isAutoRollover()) {
+                List<SprintTaskTT> active  = sprintTaskTTRepository.findByIdSprIdAndStateTask(sprId, "active");
+                List<SprintTaskTT> delayed = sprintTaskTTRepository.findByIdSprIdAndStateTask(sprId, "delayed");
+                for (SprintTaskTT st : active) {
+                    sprintTaskTTRepository.save(new SprintTaskTT(nextSprint.getSprId(), st.getId().getTaskId(), "active"));
+                }
+                for (SprintTaskTT st : delayed) {
+                    sprintTaskTTRepository.save(new SprintTaskTT(nextSprint.getSprId(), st.getId().getTaskId(), "active"));
+                }
+            }
+        }
+
+        return nextSprint;
     }
 
     // ─── Business Logic (Stored Procedure Equivalents) ───────────────────


### PR DESCRIPTION
Introduce project settings and improved UX across frontend and backend.

- Frontend: add a global Toaster component and toast utility for transient notifications.
- Sidebar: add project options menu (portal), project settings modal, close/delete modals, and handlers to update cached project state (autoRollover / autoCloseSprints flags persisted and passed to child components).
- ProjectsPage: add new/edit project flows (autoRollover toggle on create/edit), three-dot project menu, wired close/delete workflows, toasts for user feedback, and synced selection logic.
- SidebarProjectGroup: fetch and render sprints as before but with new project menu, inline settings modal, and modal wiring for close/delete actions.
- SprintPage: small navigation and toast integration updates.

- Backend: add SprintScheduler and update controllers/services/repository to support scheduling and project settings (and update application.properties). A Postman collection was also added for API exercises.

Overall this change adds per-project settings, contextual project actions (settings/close/delete), and a unified toast mechanism to improve feedback and workflow ergonomics.